### PR TITLE
LA-91 When leading is not set to AUTO, it is a number (rather than an…

### DIFF
--- a/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.js
+++ b/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.js
@@ -519,7 +519,7 @@ function ExportInDesignArticlesToFolder(
         const baselineShift = line.characters.item(0).baselineShift;
 
         // If leading is set to Auto (value = -1), estimate it as 120% of font size.
-        if (leading.equals(idd.Leading.AUTO)) {
+        if (typeof leading === "object" && leading.equals(idd.Leading.AUTO)) {
             const fontSize = line.characters.item(0).pointSize;
             leading = fontSize * 1.2;
         }


### PR DESCRIPTION
… object). Export failed in this case because the "equals" function does exist for IDD objects but not for numbers.