### PR TITLE
LA-91 Due to a typo the extractor always did fallback on the defaults…

### DIFF
--- a/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.js
+++ b/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.js
@@ -208,7 +208,7 @@ function ExportInDesignArticlesToFolder(
         let brand = null;
         let category = null;
         try {
-            brand = app.entSessions.getPublication(
+            brand = app.entSession.getPublication(
                 doc.entMetaData.get("Core_Publication")
             );
             category = app.entSession.getCategory(


### PR DESCRIPTION
… rather than resolving the brand and category from the layout. As a result, all article shape JSON files contained the defaults.