### PR TITLE
LA-109 robust shape upload - step 3

### DIFF
--- a/ArticleShapeExtractor/bootstrap.js
+++ b/ArticleShapeExtractor/bootstrap.js
@@ -78,6 +78,11 @@ Container.registerFactory("RegenerateArticleShapesService", function() {
     );
 });
 
+Container.registerFactory("BrandSectionMapResolver", function() {
+    const BrandSectionMapResolver = require("./modules/BrandSectionMapResolver.js");
+    return new BrandSectionMapResolver(Container.resolve("Logger"));
+});
+
 function initBootstrap() {
     validateHost();
 }

--- a/ArticleShapeExtractor/commands/ExtractArticleShapes.idjs
+++ b/ArticleShapeExtractor/commands/ExtractArticleShapes.idjs
@@ -26,6 +26,10 @@ await (async function main() {
             throw new NoFolderSelectedError();
         }
 
+        // Resolve the brand and sections and save them to disk.
+        await Container.resolve("BrandSectionMapResolver").run(folder);
+        
+        // Export article shapes to disk.
         let exportCounter = await Container.resolve("ExportInDesignArticlesToFolder").run(doc, folder);
         if (exportCounter === 0) {
             const { PrintLayoutAutomationError } = require('../modules/Errors.js');

--- a/ArticleShapeExtractor/commands/RegenerateArticleShapes.idjs
+++ b/ArticleShapeExtractor/commands/RegenerateArticleShapes.idjs
@@ -16,9 +16,14 @@ await (async function main() {
             throw new NoFolderSelectedError();
         }
 
+        // Resolve the brand and sections and save them to disk.
+        await Container.resolve("BrandSectionMapResolver").run(folder);
+        
+        // Export article shapes to disk.
         app.scriptPreferences.userInteractionLevel = idd.UserInteractionLevels.neverInteract;
         await Container.resolve("RegenerateArticleShapesService").run(folder);
         app.scriptPreferences.userInteractionLevel = idd.UserInteractionLevels.interactWithAll;
+
     } catch(error) {
         // First enable the user interaction again to able to show the alert.
         app.scriptPreferences.userInteractionLevel = idd.UserInteractionLevels.interactWithAll;

--- a/ArticleShapeExtractor/modules/BrandSectionMapResolver.js
+++ b/ArticleShapeExtractor/modules/BrandSectionMapResolver.js
@@ -1,0 +1,89 @@
+const { app } = require("indesign");
+
+/**
+ * Understands how to obtain the id/name info for all brands and their categories.
+ * 
+ * @constructor
+ * @param {Logger} logger 
+ */
+function BrandSectionMapResolver(logger) {
+    this._logger = logger;
+
+    /**
+     * Resolves all brand ids/names and their section ids/names from Studio Server.
+     * Writes this info into a file named "brand-section-map.json" in the provided folder.
+     * @param {Folder} exportFolder 
+     */
+    this.run = async function(exportFolder) {
+        if (!app.entSession || !app.entSession.activeServer ) {
+            return; // only provide info when having a session
+        }
+        const publicationInfos = this._getPublicationInfos(
+            app.entSession.activeUrl, app.entSession.activeTicket);
+        const brandSectionMap = this._composeBrandSectionMap(publicationInfos);
+        await this._saveBrandSectionMapToDisk(brandSectionMap, exportFolder);
+    }
+
+    /**
+     * Calls the GetPublications workflow service provided by Studio Server.
+     * Uses the JSON-RPC communication protocol.
+     * @param {string} serverUrl 
+     * @param {string} ticket 
+     * @returns {Array<Object>} List of PublicationInfo data objects.
+     */
+    this._getPublicationInfos = function(serverUrl, ticket) {
+        const separator = serverUrl.indexOf("?") === -1 ? '?' : '&';
+        const serverUrlJson = `${serverUrl}${separator}protocol=JSON`;
+        const wflRequest = {
+            "Ticket": ticket,
+            "RequestInfo": ["Categories"]
+        }
+        const rpcRequest = {
+            "method": "GetPublications",
+            "id": "1",
+            "params": [wflRequest],
+            "jsonrpc": "2.0"
+        };
+        const rawRequest = JSON.stringify(rpcRequest);
+        const rawResponse = app.jsonRequest(serverUrlJson, rawRequest);
+        const rpcResponse = JSON.parse(rawResponse);
+        const wflResponse = rpcResponse.result;
+        this._logger.info(`Resolved ${wflResponse.Publications.length} brands (with their sections) from Studio Server.`);
+        return wflResponse.Publications;
+    }
+
+    /**
+     * @param {Array<Object>} publicationInfos List of PublicationInfo data objects.
+     * @returns {Object}
+     */
+    this._composeBrandSectionMap = function(publicationInfos) {
+        const brandSetup = {};
+        for (const publicationInfo of publicationInfos) {
+            const categories = {};
+            for (const category of publicationInfo.Categories) {
+                categories[category.Name] = String(category.Id);
+            }
+            brandSetup[publicationInfo.Name] =  {
+                id: String(publicationInfo.Id),
+                sections: categories
+            }
+        }
+        return brandSetup;
+    }
+
+    /**
+     * @param {Object} brandSectionMap
+     * @param {Folder} exportFolder
+     */
+    this._saveBrandSectionMapToDisk = async function(brandSectionMap, exportFolder) {
+        const filepath = window.path.join(exportFolder, "_manifest", "brand-section-map.json");
+        const lfs = require('uxp').storage.localFileSystem;
+        const formats = require('uxp').storage.formats;
+        const jsonFile = await lfs.createEntryWithUrl(filepath, { overwrite: true });
+        const jsonString = JSON.stringify(brandSectionMap, null, 4);
+        jsonFile.write(jsonString, {format: formats.utf8}); 
+        this._logger.info(`Saved the ids/names of brands and their sections to "${filepath}".`);
+    }
+}
+
+module.exports = BrandSectionMapResolver;

--- a/ArticleShapeUploader/README.md
+++ b/ArticleShapeUploader/README.md
@@ -36,5 +36,24 @@ An example - By default, only standard element labels are supported. To allow cu
 # Usage
 ```bash
 cd ArticleShapeUploader
-node index.mjs --input_path=[your_extracted_article_shapes_folder]
+node index.mjs --input-path=[your_extracted_article_shapes_folder] --old-shapes=[delete|keep]
 ```
+
+Explanation for the above and support for additional parameters can be shown as follows:
+```bash
+cd ArticleShapeUploader
+node index.mjs --help
+```
+
+# Upload shapes to a different brand (than extracted from)
+
+The Article Shape Uploader allows 'copying' shapes from one brand to another. Assumed is that you have two similar brands, and that you have prepared both brands; You have setup the blueprints and configured additional the settings via the PLA Config Excel file and imported this in both brands. For the source brand you already have setup the article shapes and you have executed the Article Shapes Extractor tool to download all to local disk.
+
+In the export folder created by the Article Shape Extractor tool, there is a file named `_manifest/brand-section-map.json` which contains all the ids and names of the brands and sections of the Studio installation. The Article Shape Uploader will use this file in case you want to upload the article shapes for a different brand than you have extracted from. With an optional parameter named `--target-brand` you can specify the brand name to upload for:
+
+```bash
+cd ArticleShapeUploader
+node index.mjs --input-path=[your_extracted_article_shapes_folder] --old-shapes=[delete|keep] --target-brand=[brand_name]
+```
+
+Inside the article shape JSON files, the id and name of the brand and section is embedded. This represents the brand/section where you have extracted the article shape from. When specifying a different brand to upload to, the Article Shape Uploader will use the `_manifest/brand-section-map.json` file to lookup the provided brand name and resolve its id. And, it will take the section name from each article shape JSON file and lookup the section id that is configured under the target brand. Note that the tool assumes that the section names exist in both brands; source and target.

--- a/ArticleShapeUploader/index.mjs
+++ b/ArticleShapeUploader/index.mjs
@@ -42,6 +42,9 @@ const plaService = new PlaService(appSettings.getPlaServiceUrl(), appSettings.ge
 async function main() {
     try {
         dotenv.config();
+        if (cliParams.userHasAskedForHelpOnly()) {
+            return;
+        }
         const inputPath = cliParams.resolveInputPath();
         const pageLayoutSettings = pageLayoutSettingsReader.readSettings(inputPath);
         const accessToken = resolveAccessToken();

--- a/ArticleShapeUploader/modules/BrandSectionMapReader.mjs
+++ b/ArticleShapeUploader/modules/BrandSectionMapReader.mjs
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+
+export class BrandSectionMapReader {
+    #logger;
+    #jsonValidator;
+    
+    /**
+     * @param {Logger} logger 
+     * @param {JsonValidator} jsonValidator
+     */
+    constructor(logger, jsonValidator) {
+        this.#logger = logger;
+        this.#jsonValidator = jsonValidator;
+    }
+
+    /**
+     * @param {string} folderPath 
+     * @param {string} brandName
+     * @return {{brandId: string, sectionMap: Array<string,string>}}
+     */
+    readMapAndResolveBrandId(folderPath, brandName) {
+        const brandSectionMap = this.#readAndValidateMap(folderPath);
+        const brandSetup = this.#lookupBrandSetup(brandSectionMap, brandName);
+        const sectionCount = Object.keys(brandSetup.sections).length;
+        this.#logger.info(`Resolved brand id "${brandSetup.id}" and ${sectionCount} sections for brand "${brandName}".`);
+        return { brandId: brandSetup.id, sectionMap: brandSetup.sections };
+    }
+
+    /**
+     * @param {string} folderPath 
+     * @returns {Object}
+     */
+    #readAndValidateMap(folderPath) {
+        const subfolderName = "_manifest";
+        const filename = "brand-section-map.json";
+        const filepath = path.join(folderPath, subfolderName, filename);
+        let brandSectionMap = null;
+        try {
+            brandSectionMap = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+        } catch(error) {
+            throw new Error(`The file "${filepath}" is not valid JSON - ${error.message}`);
+        }
+        this.#jsonValidator.validate('brand-section-map', brandSectionMap);
+        this.#logger.info(`The "${subfolderName}/${filename}" file is valid.`);
+        return brandSectionMap;
+    }
+
+    /**
+     * @param {Object} brandSectionMap 
+     * @param {string} brandName 
+     * @returns {brandId: string, sectionMap: Array<string,string>}
+     */
+    #lookupBrandSetup(brandSectionMap, brandName) {
+        const brandSetup = brandSectionMap[brandName];
+        if (!brandSetup) {
+            throw new Error(`No mapping found for brand "${brandName}". Please check your brand setup.`);
+        }
+        return brandSetup;
+    }
+}

--- a/ArticleShapeUploader/modules/CliParams.mjs
+++ b/ArticleShapeUploader/modules/CliParams.mjs
@@ -55,8 +55,7 @@ export class CliParams {
             + "Options:\n"
             + "  --input-path=...          Path of folder that contains article shapes to upload.\n"
             + "  --old-shapes=...          How to handle the previously configured shapes. Options: 'keep' or 'delete'.\n"
-            + "  --brand-id=...            Optional. Override the brand. Overrides the brand provided by the shapes.\n"
-            + "  --section-id=...          Optional. Override the section. Overrides the section provided by the shapes.\n"
+            + "  --target-brand=...        Optional. Name of the brand to upload to. Overrides the brand provided by the shapes. Requires a _manifest/brand-section-map.json file.\n"
             + "  --no-uploads              Optional. Skip uploading files for the article shapes. Don't use for production."
         ;
         console.log(usage);
@@ -82,23 +81,12 @@ export class CliParams {
     }
 
     /**
-     * Tells which brand/section id to use. If given on CLI, those will override the default provided ones.
-     * @param {string} defaultBrandId
-     * @param {string} defaultSectionId
-     * @returns { brandId: string, sectionId: string }
+     * Returns a different brand to be used (to upload for) than the brand used to download from.
+     * @returns {string|null} The different brand, or null to use the same brand (as downloaded from).
      */
-    resolveBrandAndSectionToUse(defaultBrandId, defaultSectionId) {
+    getTargetBrandName() {
         const args = this.#getArguments();
-        const paramBrandId = 'brand-id' in args ? String(args['brand-id']) : null;
-        const paramSectionId = 'section-id' in args ? String(args['section-id']) : null;
-        if ((!paramBrandId && paramSectionId) || (paramBrandId && !paramSectionId)) {
-            this.#showUsage();
-            throw new Error("Unsupported combination of arguments. Either --brand-id or --section-id is provided. Expected both or none.");
-        }
-        const useBrandId = paramBrandId || defaultBrandId;
-        const useSectionId = paramSectionId || defaultSectionId;
-        this.#logger.info(`Targeting for brandId "${useBrandId}" and sectionId "${useSectionId}"`);
-        return { brandId: useBrandId, sectionId: useSectionId };
+        return 'target-brand' in args ? String(args['target-brand']) : null;
     }
 
     /**

--- a/ArticleShapeUploader/modules/CliParams.mjs
+++ b/ArticleShapeUploader/modules/CliParams.mjs
@@ -14,15 +14,28 @@ export class CliParams {
     }
 
     /**
+     * Whether the user has asked to show help on usage only.
+     * @returns {boolean}
+     */
+    userHasAskedForHelpOnly() {
+        const args = this.#getArguments();
+        const askedForHelp = args.hasOwnProperty('help');
+        if (askedForHelp) {
+            this.#showUsage();
+        }
+        return askedForHelp;
+    }
+
+    /**
      * Take the directory path from the CLI arguments.
      * This directory should contain the article shapes to upload.
      * @returns {string}
      */
     resolveInputPath() {
         const args = this.#getArguments();
-        if (!'input-path' in args) {
+        if (!args.hasOwnProperty('input-path') || typeof args['input-path'] !== 'string' || args['input-path'].length === 0) {
             this.#showUsage();
-            throw new Error("Argument missing: --input-path");
+            throw new Error("Argument or value missing: --input-path");
         }
         let inputPath = args['input-path'];
         if (inputPath.startsWith('~')) {
@@ -67,12 +80,12 @@ export class CliParams {
      */
     shouldDeletePreviouslyConfiguredArticleShapes() {
         const args = this.#getArguments();
-        if (!'old-shapes' in args) {
+        if (!args.hasOwnProperty('old-shapes') || typeof args['old-shapes'] !== 'string') {
             this.#showUsage();
-            throw new Error("Argument missing: --old-shapes");
+            throw new Error("Argument of value is missing: --old-shapes");
         }        
         const handleOldShapes = args['old-shapes'];
-        if (!handleOldShapes in ['keep', 'delete']) {
+        if (!['keep', 'delete'].includes(handleOldShapes)) {
             this.#showUsage();
             throw new Error(`Unsupported value provided for argument --old-shapes: ${handleOldShapes}.`);
         }
@@ -86,7 +99,7 @@ export class CliParams {
      */
     getTargetBrandName() {
         const args = this.#getArguments();
-        return 'target-brand' in args ? String(args['target-brand']) : null;
+        return args.hasOwnProperty('target-brand') ? String(args['target-brand']) : null;
     }
 
     /**

--- a/ArticleShapeUploader/modules/PlaService.mjs
+++ b/ArticleShapeUploader/modules/PlaService.mjs
@@ -193,6 +193,17 @@ export class PlaService {
             const responseJson = await response.json();
             this.#logHttpTraffic(request, articleShapeWithRenditionsDto, response, responseJson);
             if (!response.ok) {
+                if (response.status === StatusCodes.CONFLICT) { // HTTP 409
+                    const regEx1 = 'Article shape .* with this name is already configured for brand';
+                    const regEx2 = 'Article shape .* with same composition is already configured for brand';
+                    for (const pattern in [regEx1, regEx2]) {
+                        const regEx = new RegExp(pattern, 'i');
+                        if (regEx.test(responseJson.message)) {
+                            this.#logger.info(`Skipped - ${responseJson.message}`);
+                            return null;
+                        }
+                    }
+                }
                 throw new Error(`HTTP ${response.status} ${response.statusText}`);
             }
             this.#logger.info(`Created article shape "${articleShapeName}".`);

--- a/ArticleShapeUploader/modules/PlaService.mjs
+++ b/ArticleShapeUploader/modules/PlaService.mjs
@@ -199,7 +199,7 @@ export class PlaService {
                     for (const pattern in [regEx1, regEx2]) {
                         const regEx = new RegExp(pattern, 'i');
                         if (regEx.test(responseJson.message)) {
-                            this.#logger.info(`Skipped - ${responseJson.message}`);
+                            this.#logger.info(`Skipped creating article shape - ${responseJson.message}`);
                             return null;
                         }
                     }

--- a/ArticleShapeUploader/schemas/brand-section-map.schema.json
+++ b/ArticleShapeUploader/schemas/brand-section-map.schema.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://www.woodwing.com/pla/brand-section-map.schema.json",
+    "title": "Name-Id lookup table for brands and their sections",
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "required": [
+            "id",
+            "sections"
+        ],
+        "properties": {
+            "id": {
+                "type": "string",
+                "pattern": "^[0-9]+$"
+            },
+            "sections": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string",
+                    "pattern": "^[0-9]+$"
+                }
+            }
+        },
+        "additionalProperties": false
+    }
+}


### PR DESCRIPTION
extractor:
- resolve the brand setup with brands and sections (ids and names) from Studio
- write this mapping table to the _manifest folder (under the export folder), name it brand-section-map.json
 
uploader:
- support optional CLI param that specifies the brand name target to upload for, when provided:
- resolve the brand id using the brand-section-map.json file
- take the section name from the article shape JSON and resolve the section id using the brand-section-map.json file
- remove the old brand id and section id params from the CLI