### PR TITLE
LA-117 skip extract layouts (PR#4)

### DIFF
--- a/ArticleShapeExtractor/bootstrap.js
+++ b/ArticleShapeExtractor/bootstrap.js
@@ -74,6 +74,7 @@ Container.registerFactory("RegenerateArticleShapesService", function() {
     const RegenerateArticleShapesService = require("./modules/RegenerateArticleShapesService.js");
     return new RegenerateArticleShapesService(
         Container.resolve("Logger"), 
+        Container.resolve("VersionUtils"),
         Container.resolve("Settings").getRegenerateArticleShapesQueryName(),
         Container.resolve("ExportInDesignArticlesToFolder"),
     );

--- a/ArticleShapeExtractor/bootstrap.js
+++ b/ArticleShapeExtractor/bootstrap.js
@@ -73,6 +73,7 @@ Container.registerFactory("ExportInDesignArticlesToFolder", function() {
 Container.registerFactory("RegenerateArticleShapesService", function() {
     const RegenerateArticleShapesService = require("./modules/RegenerateArticleShapesService.js");
     return new RegenerateArticleShapesService(
+        Container.resolve("Logger"), 
         Container.resolve("Settings").getRegenerateArticleShapesQueryName(),
         Container.resolve("ExportInDesignArticlesToFolder"),
     );

--- a/ArticleShapeExtractor/commands/RegenerateArticleShapes.idjs
+++ b/ArticleShapeExtractor/commands/RegenerateArticleShapes.idjs
@@ -23,6 +23,7 @@ await (async function main() {
         app.scriptPreferences.userInteractionLevel = idd.UserInteractionLevels.neverInteract;
         await Container.resolve("RegenerateArticleShapesService").run(folder);
         app.scriptPreferences.userInteractionLevel = idd.UserInteractionLevels.interactWithAll;
+        alert("Article Shapes are regenerated.");
 
     } catch(error) {
         // First enable the user interaction again to able to show the alert.

--- a/ArticleShapeExtractor/modules/Errors.js
+++ b/ArticleShapeExtractor/modules/Errors.js
@@ -1,6 +1,6 @@
 class ArgumentError extends Error {
-    constructor(argument) {
-        super(`Bad argument '${argument}' provided.`);
+    constructor(message) {
+        super(`Bad argument provided. ${message}`);
         this.name = this.constructor.name;
     }
 }

--- a/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.js
+++ b/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.js
@@ -28,7 +28,9 @@ function ExportInDesignArticlesToFolder(
      * @returns {Number} Count of exported article shapes.
      */
     this.run = async function(doc, folder) {
-        await this._pageLayoutSettings.exportSettings(doc, folder);
+        if (!(await this._pageLayoutSettings.exportSettings(doc, folder))) {
+            return 0;
+        }
 
         const lfs = require('uxp').storage.localFileSystem;
         const docName = doc.saved ? lfs.getNativePath(await doc.fullName) : doc.name;

--- a/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.js
+++ b/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.js
@@ -100,6 +100,7 @@ function ExportInDesignArticlesToFolder(
                 }
             }
             if (pageItems.length === 0) {
+                this._logger.warning("Excluded article '{}' from export because it has no page items.", article.name);
                 continue;
             }
             const managedArticle = this._getManagedArticleFromPageItems(pageItems)
@@ -113,6 +114,7 @@ function ExportInDesignArticlesToFolder(
                 this._logger.error(message);
                 continue;
             }
+            this._logger.info("Exporting article '{}'...", article.name);
             await this._exportArticlePageItems(doc, folder, articleShapeJson.shapeTypeName, articleIndex, pageItems, articleShapeJson)
             exportCounter++;
         }
@@ -300,7 +302,7 @@ function ExportInDesignArticlesToFolder(
         let pageItemsIds = [];
         for (let index = 0; index < pageItems.length; index++) {
             const pageItem = pageItems[index];
-            this._logger.info(`Exporting '${pageItem.constructor.name}' page item with id '${pageItem.id}'.`);
+            this._logger.debug(`Exporting '${pageItem.constructor.name}' page item with id '${pageItem.id}'.`);
             pageItemsIds.push(pageItem.id);
         }
         doc.exportPageItemsToSnippet(snippetFile, pageItemsIds);

--- a/ArticleShapeExtractor/modules/Logger.js
+++ b/ArticleShapeExtractor/modules/Logger.js
@@ -126,15 +126,7 @@ function Logger(filePath, filename, logLevel, wipe) {
 	 * @returns {String} UTC date and time with milliseconds in ISO 8601 format.
 	 */
 	this._getDateTimeWithMsAsString = function() {
-		const date = new Date();
-		const dateString = date.getUTCFullYear() 
-			+ '-' + date.getUTCMonth().toString().padStart(2, "0") 
-			+ '-' + date.getUTCDay().toString().padStart(2, "0");
-		const timeString = date.getUTCHours().toString().padStart(2, "0") 
-			+ ':' + date.getUTCMinutes().toString().padStart(2, "0") 
-			+ ':' + date.getUTCSeconds().toString().padStart(2, "0")
-			+ '.' + date.getUTCMilliseconds().toString().padStart(3, "0");
-		return dateString + 'T' + timeString + 'Z';
+		return new Date().toISOString();
 	};
 
 	this._getLogFilepath = function() {

--- a/ArticleShapeExtractor/modules/PageLayoutSettings.js
+++ b/ArticleShapeExtractor/modules/PageLayoutSettings.js
@@ -21,7 +21,7 @@ function PageLayoutSettings(logger) {
      * @returns {boolean} True when the settings are matching (or new), false otherwise.
      */
     this.exportSettings = async function(doc, folder) {
-        const exportedSuccessfully = false;
+        let exportedSuccessfully = false;
         const docName = doc.saved ? lfs.getNativePath(await doc.fullName) : doc.name;
         this._logger.info("Exporting Document Settings for layout '{}'.", docName);
         app.scriptPreferences.measurementUnit = idd.MeasurementUnits.POINTS;

--- a/ArticleShapeExtractor/modules/PageLayoutSettings.js
+++ b/ArticleShapeExtractor/modules/PageLayoutSettings.js
@@ -37,7 +37,9 @@ function PageLayoutSettings(logger) {
             exportedSuccessfully = true;
         } catch(error) {
             const { ConfigurationError } = require('./Errors.js');
-            if (!(error instanceof ConfigurationError)) {
+            if (error instanceof ConfigurationError) {
+                this._logger.error(error.message);
+            } else {
                 this._logger.logError(error);
             }
             alert("An error occurred: " + error.message);

--- a/ArticleShapeExtractor/modules/RegenerateArticleShapesService.js
+++ b/ArticleShapeExtractor/modules/RegenerateArticleShapesService.js
@@ -75,7 +75,7 @@ function RegenerateArticleShapesService(logger, versionUtils, userQueryName, exp
                 if (mapItem) for (const oldFile of mapItem.files) {
                     await this._deleteFile(oldFile);
                 }
-                const theOpenDoc = app.openObject(wflObject.ID);
+                const theOpenDoc = app.openObject(wflObject.ID, false); // false: no checkout
                 await this._exportInDesignArticlesToFolder.run(theOpenDoc, folder);
                 theOpenDoc.close(idd.SaveOptions.no);
             }

--- a/ArticleShapeExtractor/modules/RegenerateArticleShapesService.js
+++ b/ArticleShapeExtractor/modules/RegenerateArticleShapesService.js
@@ -45,9 +45,9 @@ function RegenerateArticleShapesService(logger, userQueryName, exportInDesignArt
         await this._queryObjects(searchParams, resolveProperties, async (wflObject) => {
             //this._logger.debug('QueryObjects resolved object: {}', JSON.stringify(wflObject, null, 4));
             if (fileMap.get(wflObject.ID) === wflObject.Version) {
-                this._logger.info('Skipped extracting InDesign Articles for layout document because ' + 
-                    `layout id ${wflObject.ID} with version ${wflObject.Version} already exists ` +
-                    'in export folder. This implies it is already handled in preceding runs before.');
+                this._logger.info(`Skipped extracting InDesign Articles for layout '${wflObject.Name}'; ` + 
+                    `Article Shapes (JSON files) for layout id ${wflObject.ID} with version ${wflObject.Version} ` +
+                    'already exists in export folder.');
             } else {
                 const theOpenDoc = app.openObject(wflObject.ID);
                 await this._exportInDesignArticlesToFolder.run(theOpenDoc, folder);

--- a/ArticleShapeExtractor/modules/RegenerateArticleShapesService.js
+++ b/ArticleShapeExtractor/modules/RegenerateArticleShapesService.js
@@ -180,7 +180,10 @@ function RegenerateArticleShapesService(logger, userQueryName, exportInDesignArt
             this._logger.info(`Running QueryObjects page#${queryCount}...`);
             response = await this._queryObjectsOneResultPage(
                 searchParams, resolveProperties, firstEntry, callbackObjectResolved);
-            firstEntry = response.FirstEntry + response.ListedEntries;
+            // firstEntry = response.FirstEntry + response.ListedEntries;
+            //  L> Assumed is that the status of a processed layout is changed, and that
+            //     the User Query has a layout status in its filters. Then we should NOT page
+            //     results because processed layouts already disappear from the search results.
         } while (response.ListedEntries > 0 && queryCount < maxQueryHit);
         if (queryCount === maxQueryHit) {
             const { PrintLayoutAutomationError } = require('./Errors.js');

--- a/ArticleShapeExtractor/modules/RegenerateArticleShapesService.js
+++ b/ArticleShapeExtractor/modules/RegenerateArticleShapesService.js
@@ -3,10 +3,12 @@ const idd = require("indesign");
 
 /**
  * @constructor
+ * @param {Logger} logger
  * @param {String} userQueryName
  * @param {ExportInDesignArticlesToFolder} exportInDesignArticlesToFolder
  */
-function RegenerateArticleShapesService(userQueryName, exportInDesignArticlesToFolder) {
+function RegenerateArticleShapesService(logger, userQueryName, exportInDesignArticlesToFolder) {
+    this._logger = logger;
     this._userQueryName = userQueryName;
     this._exportInDesignArticlesToFolder = exportInDesignArticlesToFolder;
 


### PR DESCRIPTION
The Regenerate Article Shapes operation for 375 layouts took around 5 minutes whereby 345 layouts got skipped because of they got found in the export folder and the other 30 layouts got re-processed. For all 375 the layout status was send to next regardlessly.