### PR TITLE
When the document settings found in the export folder mismatch with t…

### DIFF
--- a/ArticleShapeUploader/index.mjs
+++ b/ArticleShapeUploader/index.mjs
@@ -136,8 +136,12 @@ async function assureTallyPageLayoutSettings(accessToken, brandId, inputPageLayo
     }
     jsonValidator.validate('page-layout-settings', plaPageLayoutSettings);
     if (diff(plaPageLayoutSettings, inputPageLayoutSettings)) {
-        logger.error("The page layout settings retrieved from PLA service differ from the ones "
-            + "read from input folder. ", plaPageLayoutSettings, inputPageLayoutSettings);
+        logger.error( "Page layout settings differ:",
+            "\n1) retrieved from PLA service:\n", plaPageLayoutSettings,
+            "\n2) read from input folder:\n", inputPageLayoutSettings);
+        throw new Error(
+            "The page layout settings retrieved from PLA service "
+            + "differ from the ones read from input folder.");
     }
 }
 


### PR DESCRIPTION
…he ones found on PLA service, the uploader logged an error but simply continued. It should stop to avoid creating a mess.