### PR TITLE
LA-118 uploader preflight check on brands/sections

### DIFF
--- a/ArticleShapeExtractor/jsconfig.json
+++ b/ArticleShapeExtractor/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "es2022",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "baseUrl": ".", // root folder
+    "paths": {
+      "*": ["./*"]
+    }
+  },
+  "include": ["./**/*.mjs", "./**/*.idjs", "./**/*.js"]
+}

--- a/ArticleShapeUploader/index.mjs
+++ b/ArticleShapeUploader/index.mjs
@@ -188,7 +188,8 @@ async function scanDirAndUploadFiles(folderPath, accessToken, brandId) {
             composeFileRenditionDto('snapshot', 'image/jpeg', 'jpg'),
             composeFileRenditionDto('definition', 'application/xml', 'idms'),
         ] : [];
-        const sectionId = brandSectionMapReader.resolveSectionId(articleShapeJson.sectionName);
+        const sectionId = brandSectionMapReader.resolveSectionId(
+            articleShapeJson.brandName, articleShapeJson.sectionName);
         await uploadArticleShapeWithFiles(
             accessToken, brandId, sectionId, baseName, articleShapeJson, localFiles, fileRenditions);        
         return true;

--- a/ArticleShapeUploader/jsconfig.json
+++ b/ArticleShapeUploader/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "es2022",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "baseUrl": ".", // root folder
+    "paths": {
+      "*": ["./*"]
+    }
+  },
+  "include": ["./**/*.mjs"]
+}

--- a/ArticleShapeUploader/modules/BrandSectionMapReader.mjs
+++ b/ArticleShapeUploader/modules/BrandSectionMapReader.mjs
@@ -9,6 +9,9 @@ export class BrandSectionMapReader {
     /** @type {JsonValidator} */
     #jsonValidator;
 
+    /** @type {string|null} */
+    #brandName;
+    
     /** @type {Object|null} */
     #brandSections;
     
@@ -32,6 +35,7 @@ export class BrandSectionMapReader {
         const brandSetup = this.#lookupBrandSetup(brandSectionMap, brandName);
         const sectionCount = Object.keys(brandSetup.sections).length;
         this.#logger.info(`Resolved brand id "${brandSetup.id}" and ${sectionCount} sections for brand "${brandName}".`);
+        this.#brandName = brandName;
         this.#brandSections = brandSetup.sections;
         return brandSetup.id;
     }
@@ -85,12 +89,18 @@ export class BrandSectionMapReader {
     }
 
     /**
+     * @param {string} brandName 
      * @param {string} sectionName 
      * @returns {string} Section id.
      */
-    resolveSectionId(sectionName) {
+    resolveSectionId(brandName, sectionName) {
         if (!this.#brandSections) {
             throw new Error(`The brand sections were not resolved yet.`);
+        }
+        if (brandName !== this.#brandName) {
+            throw new Error(`The given brand "${brandName}" is not the same as brand "${this.#brandName}" being handled. ` +
+                'Mixed brand or brand switches are not supported.'
+            );
         }
         const sectionId = this.#brandSections[sectionName];
         if (!sectionId) {

--- a/ArticleShapeUploader/modules/BrandSectionMapReader.mjs
+++ b/ArticleShapeUploader/modules/BrandSectionMapReader.mjs
@@ -8,6 +8,9 @@ export class BrandSectionMapReader {
 
     /** @type {JsonValidator} */
     #jsonValidator;
+
+    /** @type {Object|null} */
+    #brandSections;
     
     /**
      * @param {ColoredLogger} logger 
@@ -16,19 +19,21 @@ export class BrandSectionMapReader {
     constructor(logger, jsonValidator) {
         this.#logger = logger;
         this.#jsonValidator = jsonValidator;
+        this.#brandSections = null;
     }
 
     /**
      * @param {string} folderPath 
      * @param {string} brandName
-     * @return {{brandId: string, sectionMap: Array<string,string>}}
+     * @return {string} Brand id.
      */
     readMapAndResolveBrandId(folderPath, brandName) {
         const brandSectionMap = this.#readAndValidateMap(folderPath);
         const brandSetup = this.#lookupBrandSetup(brandSectionMap, brandName);
         const sectionCount = Object.keys(brandSetup.sections).length;
         this.#logger.info(`Resolved brand id "${brandSetup.id}" and ${sectionCount} sections for brand "${brandName}".`);
-        return { brandId: brandSetup.id, sectionMap: brandSetup.sections };
+        this.#brandSections = brandSetup.sections;
+        return brandSetup.id;
     }
 
     /**
@@ -36,9 +41,7 @@ export class BrandSectionMapReader {
      * @returns {Object}
      */
     #readAndValidateMap(folderPath) {
-        const subfolderName = "_manifest";
-        const filename = "brand-section-map.json";
-        const filepath = path.join(folderPath, subfolderName, filename);
+        const filepath = path.join(folderPath, this.#getRelativeMapFilepath());
         let brandSectionMap = null;
         try {
             brandSectionMap = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
@@ -46,20 +49,53 @@ export class BrandSectionMapReader {
             throw new Error(`The file "${filepath}" is not valid JSON - ${error.message}`);
         }
         this.#jsonValidator.validate('brand-section-map', brandSectionMap);
-        this.#logger.info(`The "${subfolderName}/${filename}" file is valid.`);
+        this.#logger.info(`The "${this.#getRelativeMapFilepath()}" file is valid.`);
         return brandSectionMap;
+    }
+
+    /**
+     * Compose relative path of the mapping file: _manifest/brand-section-map.json
+     * @returns {string}
+     */
+    #getRelativeMapFilepath() {
+        const subfolderName = "_manifest";
+        const filename = "brand-section-map.json";
+        return path.join(subfolderName, filename);
     }
 
     /**
      * @param {Object} brandSectionMap 
      * @param {string} brandName 
-     * @returns {brandId: string, sectionMap: Array<string,string>}
+     * @returns {{id: string, sections: Object}} Brand id and the sections configured under the brand.
      */
     #lookupBrandSetup(brandSectionMap, brandName) {
         const brandSetup = brandSectionMap[brandName];
         if (!brandSetup) {
-            throw new Error(`No mapping found for brand "${brandName}". Please check your brand setup.`);
+            throw new Error(`No mapping found for brand "${brandName}". ${this.#getConfigTip()}`);
         }
         return brandSetup;
+    }
+
+    /**
+     * Compose a help string to show user in case of configuration troubles.
+     * @returns {string}
+     */
+    #getConfigTip() {
+        return `Please check your brand setup. And check the "${this.#getRelativeMapFilepath()}" file.`;
+    }
+
+    /**
+     * @param {string} sectionName 
+     * @returns {string} Section id.
+     */
+    resolveSectionId(sectionName) {
+        if (!this.#brandSections) {
+            throw new Error(`The brand sections were not resolved yet.`);
+        }
+        const sectionId = this.#brandSections[sectionName];
+        if (!sectionId) {
+            throw new Error(`The section "${sectionName}" was not found. ${this.#getConfigTip()}`);
+        }
+        return sectionId;
     }
 }

--- a/ArticleShapeUploader/modules/CliParams.mjs
+++ b/ArticleShapeUploader/modules/CliParams.mjs
@@ -69,7 +69,7 @@ export class CliParams {
             + "Options:\n"
             + "  --input-path=...          Path of folder that contains article shapes to upload.\n"
             + "  --old-shapes=...          How to handle the previously configured shapes. Options: 'keep' or 'delete'.\n"
-            + "  --target-brand=...        Optional. Name of the brand to upload to. Overrides the brand provided by the shapes. Requires a _manifest/brand-section-map.json file.\n"
+            + "  --target-brand=...        Optional. Name of the brand to upload to. Overrides the brand provided by the shapes.\n"
             + "  --no-uploads              Optional. Skip uploading files for the article shapes. Don't use for production."
         ;
         console.log(usage);

--- a/ArticleShapeUploader/modules/PlaService.mjs
+++ b/ArticleShapeUploader/modules/PlaService.mjs
@@ -72,7 +72,7 @@ export class PlaService {
             const responseJson = await response.json();
             this.#logHttpTraffic(request, null, response, responseJson);
             if (response.ok) {
-                this.#logger.debug(`Validated brand setup. Found ${responseJson.length} issues.`);
+                this.#logger.debug(`Validated brand setup. Found ${responseJson.length} problems.`);
                 return responseJson;
             }
             throw new Error(`HTTP ${response.status} ${response.statusText}`);


### PR DESCRIPTION
We used to use the brand-section mapping JSON file to lookup the brands and sections only for the 'copy' operation whereby you extract shapes from brand A and upload them into brand B. Now, we also use the mapper for the normal flow whereby you extract and upload under just one brand. 

Doing so, the brand id and section ids are resolved by given their names embedded in the shape JSON files. Potential brand context switches are detected and not allowed. This could happen if you extract for two brands, while you attempt to upload into one only; It will stick to the brand found in the first shape JSON and disallow uploading for other brands.

As discussed, we won't preflight check the print components configured in the CS admin console. This we can pickup later.