### PR TITLE
LA-224 AI fitting step 8 - Adobe types, 2nd phase

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ArticleShapeExtractor/types/adobe"]
-	path = ArticleShapeExtractor/types/adobe
-	url = https://github.com/docsforadobe/Types-for-Adobe

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,10 +7,14 @@
         "idms",
         "idjs",
         "indesign",
+        "layouter",
         "ltrim",
         "malpositioned",
+        "outerbound",
+        "prefs",
         "rtrim",
-        "stroustrup"
+        "stroustrup",
+        "ungroup"
     ],
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "[javascript]": {

--- a/ArticleShapeExtractor/bootstrap.js
+++ b/ArticleShapeExtractor/bootstrap.js
@@ -2,6 +2,7 @@ require("./extensions/String.js");
 require("./extensions/globals.js");
 require("./extensions/lodash.min.js");
 require("./types.d.js");
+require("./types.dto.d.js");
 const Container = require("./modules/Container.cjs");
 
 Container.registerSingleton("Settings", function () {

--- a/ArticleShapeExtractor/commands/ExtractArticleShapes.idjs
+++ b/ArticleShapeExtractor/commands/ExtractArticleShapes.idjs
@@ -17,6 +17,7 @@ await (async function main () {
 
         // Prompt the user to select the folder for saving the snippets.
         alert("Select a folder to save the Article Shapes.");
+        /** @type {UXP.storage.FileSystemProvider} */
         const lfs = require("uxp").storage.localFileSystem;
         const domains = require("uxp").storage.domains;
         const folder = await lfs.getFolder({ initialDomain: domains.userDocuments });

--- a/ArticleShapeExtractor/commands/RegenerateArticleShapes.idjs
+++ b/ArticleShapeExtractor/commands/RegenerateArticleShapes.idjs
@@ -9,6 +9,7 @@ await (async function main () {
 
         // Prompt the user to select the folder for saving the Article Shapes.
         alert("Select a folder to save the Article Shapes.");
+        /** @type {UXP.storage.FileSystemProvider} */
         const lfs = require("uxp").storage.localFileSystem;
         const domains = require("uxp").storage.domains;
         const folder = await lfs.getFolder({ initialDomain: domains.userDocuments });

--- a/ArticleShapeExtractor/doc/DEVELOPMENT.md
+++ b/ArticleShapeExtractor/doc/DEVELOPMENT.md
@@ -25,41 +25,6 @@ Now your modifications to the scripts are directly reflected to both GitHub and 
 5. IDJS scripts in the `Startup Scripts` folder are not recognized/executed by InDesign.
 6. Bullets 3, 4 and 5 make it impossible to add a menu item or shortcut key for a UXP/IDJS script.
 
-## How are the InDesign script types linked?
-
-> There is ***no*** need for action; This chapter just explains how it was setup for you already.
-
-The `docsforadobe` repo is linked to our repo:
-```bash
-cd ArticleShapeExtractor
-git submodule add https://github.com/docsforadobe/Types-for-Adobe types/adobe
-```
-
-The types are included via `jsconfig.json`:
-```json
-{
-  "compilerOptions": {
-    "lib": ["es2018"]
-  },
-  "include": [
-    "types/adobe/InDesign/2023/*.d.ts",
-    "types/adobe/shared/*.d.ts"
-  ]
-}
-```
-
-> Note that InDesign 2023 types are included while 2024 is supported. Reason is that, at the time writing, types for 2024 were not available.
-
-## How to update the InDesign types?
-
-Adobe may update the DOM or improve the repo. This is how you can reflect their changes into our repo:
-```bash
-cd ArticleShapeExtractor
-git submodule update --remote
-```
-
-VS Code will pick up the new types automatically.
-
 ## Code checker and formatter
 
 ### Installation

--- a/ArticleShapeExtractor/extensions/globals.js
+++ b/ArticleShapeExtractor/extensions/globals.js
@@ -1,7 +1,7 @@
 /**
  * Make an alert() function available on global level.
  * @param {string} msg
- * @param {string|undefined} caption
+ * @param {string} [caption]
  * @returns
  */
 globalThis.alert = function (msg, caption) {

--- a/ArticleShapeExtractor/jsconfig.json
+++ b/ArticleShapeExtractor/jsconfig.json
@@ -14,21 +14,11 @@
     // Strict mode for JS code validation. Applies to tsc and VS Code.
     //"strict": true, // TODO
 
-    // Make UXP types available for VS Code.
-    // Note that typeRoots overrides defaults, so be sure to include the implicit @types as well.
-    "typeRoots": [
-      "node_modules/@adobe/cc-ext-uxp-types",
-      "node_modules/@types",
-    ],
-        
     // No fake path aliases.
     "baseUrl": ".", // root folder
     
     // JS scripts do not run in a browser (DOM) but in InDesign, hence turn off lib.dom.d.ts.
-    // Note that both web browser DOM and InDesign define e.g. a global Document.
-    // Important is to exclude the DOM and so the InDesign Document definition is used.
     // By picking "es2018" it includes e.g. Promise (etc) but does NOT include browser DOM.
-    // See doc/DEVELOPMENT.md how to manage.
     "lib": ["es2018"],
     
     "paths": {
@@ -36,17 +26,11 @@
     }
   },
   "include": [
-    // NOTE: The "indesign-aliases.d.ts" file is using globalThis, hence must be included BEFORE "uxp-aliases.d.ts"
-    //       otherwise e.g. the Document type definition is taken from UXP rather than InDesign.
-    "types/indesign-aliases.d.ts", // See note above.
-    "types/adobe/InDesign/2023/*.d.ts",
-    "types/adobe/shared/*.d.ts",
-    "types/uxp-aliases.d.ts", // See note above.
-    "types/dto.d.js",
     "./**/*.cjs",
     "./**/*.mjs",
     "./**/*.idjs",
     "./**/*.js",
+    "types/*.d.ts"
   ],
   "exclude": [
     "node_modules"

--- a/ArticleShapeExtractor/modules/BrandSectionMapResolver.cjs
+++ b/ArticleShapeExtractor/modules/BrandSectionMapResolver.cjs
@@ -1,3 +1,5 @@
+const idd = require("indesign");
+
 /**
  * Understands how to obtain the id/name info for all brands and their categories
  * and how to provides that information in the _manifest subfolder of the export folder.
@@ -27,7 +29,7 @@ class BrandSectionMapResolver {
     /**
      * Resolves all brand ids/names and their section ids/names from Studio Server.
      * Writes this info into a file named "brand-section-map.json" in the provided folder.
-     * @param {UXP.Folder} exportFolder
+     * @param {UXP.storage.Folder} exportFolder
      */
     async run (exportFolder) {
         if (!this.#studioJsonRpcClient.hasSession()) {
@@ -59,11 +61,12 @@ class BrandSectionMapResolver {
 
     /**
      * @param {Object} brandSectionMap
-     * @param {UXP.Folder} exportFolder
+     * @param {UXP.storage.Folder} exportFolder
      */
     async #saveBrandSectionMapToDisk (brandSectionMap, exportFolder) {
         const filepath = window.path.join(exportFolder, "_manifest", "brand-section-map.json");
         await this.#fileUtils.getOrCreateSubFolder(exportFolder, "_manifest");
+        /** @type {UXP.storage.FileSystemProvider} */
         const lfs = require("uxp").storage.localFileSystem;
         const formats = require("uxp").storage.formats;
         const jsonFile = await lfs.createEntryWithUrl(filepath, { overwrite: true });

--- a/ArticleShapeExtractor/modules/Container.cjs
+++ b/ArticleShapeExtractor/modules/Container.cjs
@@ -1,11 +1,11 @@
 class Container {
-    /** @type {Array<{
-            factoryFunction: Function,
-            providerType: string,
-            lastInstance: Object,
-            >}
-        }
-    */
+    /**
+     * @type {Record<string, {
+     *   factoryFunction: Function,
+     *   providerType: string,
+     *   lastInstance: Object
+     * }>}
+     */
     #registrations = {};
 
     /**

--- a/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.cjs
+++ b/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.cjs
@@ -43,14 +43,15 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * @param {IDD.Document} doc
-     * @param {UXP.Folder} folder
-     * @returns {number} Count of exported article shapes.
+     * @param {UXP.storage.Folder} folder
+     * @returns Promise<{number}> Count of exported article shapes.
      */
     async run (doc, folder) {
         if (!(await this.#pageLayoutSettings.exportSettings(doc, folder))) {
             return 0;
         }
 
+        /** @type {UXP.storage.FileSystemProvider} */
         const lfs = require("uxp").storage.localFileSystem;
         const docName = doc.saved ? lfs.getNativePath(await doc.fullName) : doc.name;
         this.#logger.info("Extracting InDesign Articles for layout document '{}'.", docName);
@@ -69,14 +70,15 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * @param {IDD.Document} doc
-     * @param {UXP.Folder} folder
+     * @param {UXP.storage.Folder} folder
      * @param {IDD.Article} article
      * @param {number} articleIndex
-     * @returns {boolean} Whether or not successful.
+     * @returns Promise>{boolean}> Whether or not successful.
      */
     async #exportArticle (doc, folder, article, articleIndex) {
-        /** @type {IDD.ArticleMember[]} */
-        const elements = article.articleMembers.everyItem().getElements();
+        const articleMembers = /** @type {IDD.ArticleMember} */
+            (/** @type {unknown} */(article.articleMembers.everyItem()));
+        const elements = articleMembers.getElements();
         const outerBounds = this.#getOuterboundOfArticleShape(elements);
         let articleShapeJson = this.#composeArticleShapeJson(doc, article.name, outerBounds);
         if (articleShapeJson === null) {
@@ -120,7 +122,7 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * @param {IDD.Article} article
-     * @param {IDD.Element[]} elements
+     * @param {IDD.ArticleMember[]} elements
      * @param {GeoBounds} outerBounds
      * @param {ArticleShapeJson} articleShapeJson
      * @returns {IDD.PageItem[]}
@@ -132,9 +134,10 @@ class ExportInDesignArticlesToFolder {
             const element = elements[elementIndex];
             const geometricBounds = this.#composeGeometricBounds(outerBounds.topLeftX, outerBounds.topLeftY, element.itemRef);
             if (this.#inDesignArticleService.isValidTextFrame(element.itemRef)) {
-                const threadedFrames = this.#getThreadedFrames(element.itemRef);
+                const textFrame = /** @type {IDD.TextFrame} */(element.itemRef);
+                const threadedFrames = this.#getThreadedFrames(textFrame);
                 let textComponent = {
-                    "type": element.itemRef.elementLabel,
+                    "type": textFrame.elementLabel,
                     "words": 0,
                     "characters": 0,
                     "firstParagraphStyle": "",
@@ -143,7 +146,8 @@ class ExportInDesignArticlesToFolder {
 
                 // Add the name of the first paragraph style used in the chain of threaded frames.
                 if (threadedFrames[0].paragraphs.length > 0) {
-                    textComponent.firstParagraphStyle = threadedFrames[0].paragraphs.item(0).appliedParagraphStyle.name;
+                    const paragraphStyle = /** @type {paragraphStyle} */(threadedFrames[0].paragraphs.item(0).appliedParagraphStyle);
+                    textComponent.firstParagraphStyle = paragraphStyle.name;
                 }
 
                 for (let frameIndex = 0; frameIndex < threadedFrames.length; frameIndex++) {
@@ -233,10 +237,10 @@ class ExportInDesignArticlesToFolder {
     /**
      * Compose a unique name that can be used as a base to compose export filenames.
      * @param {IDD.Document} doc
-     * @param {UXP.Folder} folder
+     * @param {UXP.storage.Folder} folder
      * @param {string} shapeTypeName
      * @param {number} articleIndex
-     * @returns {string}
+     * @returns {Promise<string>}
      */
     async #getFileBaseName (doc, folder, shapeTypeName, articleIndex) {
         let fileName = doc.name + " " + shapeTypeName + " " + (articleIndex + 1);
@@ -266,10 +270,10 @@ class ExportInDesignArticlesToFolder {
      */
     #composeGeometricBounds (topLeftX, topLeftY, pageItem) {
         return {
-            "x": this.#roundTo3Decimals(pageItem.geometricBounds[1] - topLeftX),
-            "y": this.#roundTo3Decimals(pageItem.geometricBounds[0] - topLeftY),
-            "width": this.#roundTo3Decimals(pageItem.geometricBounds[3] - pageItem.geometricBounds[1]),
-            "height": this.#roundTo3Decimals(pageItem.geometricBounds[2] - pageItem.geometricBounds[0]),
+            "x": this.#roundTo3Decimals(Number(pageItem.geometricBounds[1]) - topLeftX),
+            "y": this.#roundTo3Decimals(Number(pageItem.geometricBounds[0]) - topLeftY),
+            "width": this.#roundTo3Decimals(Number(pageItem.geometricBounds[3]) - Number(pageItem.geometricBounds[1])),
+            "height": this.#roundTo3Decimals(Number(pageItem.geometricBounds[2]) - Number(pageItem.geometricBounds[0])),
         };
     }
 
@@ -322,10 +326,10 @@ class ExportInDesignArticlesToFolder {
         // Set the foldLine property when the article shape does crossover the fold line of the spread.
         const geometricBoundsRight = articleShapeJson.geometricBounds.x + articleShapeJson.geometricBounds.width;
         const crossoverFoldLine =
-            articleShapeJson.geometricBounds.x < doc.documentPreferences.pageWidth
-            && doc.documentPreferences.pageWidth < geometricBoundsRight;
+            Number(articleShapeJson.geometricBounds.x) < Number(doc.documentPreferences.pageWidth)
+            && Number(doc.documentPreferences.pageWidth) < geometricBoundsRight;
         if (crossoverFoldLine) {
-            articleShapeJson.foldLine = doc.documentPreferences.pageWidth - articleShapeJson.geometricBounds.x;
+            articleShapeJson.foldLine = Number(doc.documentPreferences.pageWidth) - articleShapeJson.geometricBounds.x;
         }
         return articleShapeJson;
     }
@@ -351,14 +355,15 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * @param {IDD.Document} doc
-     * @param {UXP.Folder} folder
+     * @param {UXP.storage.Folder} folder
      * @param {string} shapeTypeName
      * @param {number} articleIndex
      * @param {IDD.PageItem[]} pageItems
      * @param {ArticleShapeJson} articleShapeJson
-     * @returns {boolean} Whether or not successful.
+     * @returns {Promise<boolean>} Whether or not successful.
      */
     async #exportArticlePageItems (doc, folder, shapeTypeName, articleIndex, pageItems, articleShapeJson) {
+        /** @type {UXP.storage.FileSystemProvider} */
         const lfs = require("uxp").storage.localFileSystem;
 
         const baseFileName = await this.#getFileBaseName(doc, folder, shapeTypeName, articleIndex);
@@ -424,8 +429,8 @@ class ExportInDesignArticlesToFolder {
     /**
      * Save JSON data to a file on disk.
      * @param {ArticleShapeJson} jsonData - The JSON object to save.
-     * @param {UXP.File} file
-     * @returns {boolean} Whether or not successful.
+     * @param {UXP.storage.File} file
+     * @returns {Promise<boolean>} Whether or not successful.
      */
     async #saveJsonToDisk (jsonData, file) {
         let isSaved = false;
@@ -496,15 +501,16 @@ class ExportInDesignArticlesToFolder {
             let threadedFrames;
 
             if (j == 0) {
-                topLeftX = element.itemRef.geometricBounds[1];
-                topLeftY = element.itemRef.geometricBounds[0];
-                bottomRightX = element.itemRef.geometricBounds[3];
-                bottomRightY = element.itemRef.geometricBounds[2];
+                topLeftX = Number(element.itemRef.geometricBounds[1]);
+                topLeftY = Number(element.itemRef.geometricBounds[0]);
+                bottomRightX = Number(element.itemRef.geometricBounds[3]);
+                bottomRightY = Number(element.itemRef.geometricBounds[2]);
             }
 
-            //Create an array with all thread frames (images dont have threaded frames)
+            //Create an array with all thread frames (images don't have threaded frames)
             if (this.#inDesignArticleService.isValidTextFrame(element.itemRef)) {
-                threadedFrames = this.#getThreadedFrames(element.itemRef);
+                const textFrame = /** @type {IDD.TextFrame} */(element.itemRef);
+                threadedFrames = this.#getThreadedFrames(textFrame);
             }
             else {
                 threadedFrames = [element.itemRef];
@@ -513,17 +519,17 @@ class ExportInDesignArticlesToFolder {
             for (let k = 0; k < threadedFrames.length; k++) {
                 const frame = threadedFrames[k];
 
-                if (frame.geometricBounds[1] < topLeftX) {
-                    topLeftX = frame.geometricBounds[1];
+                if (Number(frame.geometricBounds[1]) < topLeftX) {
+                    topLeftX = Number(frame.geometricBounds[1]);
                 }
-                if (frame.geometricBounds[0] < topLeftY) {
-                    topLeftY = frame.geometricBounds[0];
+                if (Number(frame.geometricBounds[0]) < topLeftY) {
+                    topLeftY = Number(frame.geometricBounds[0]);
                 }
-                if (frame.geometricBounds[3] > bottomRightX) {
-                    bottomRightX = frame.geometricBounds[3];
+                if (Number(frame.geometricBounds[3]) > bottomRightX) {
+                    bottomRightX = Number(frame.geometricBounds[3]);
                 }
-                if (frame.geometricBounds[2] > bottomRightY) {
-                    bottomRightY = frame.geometricBounds[2];
+                if (Number(frame.geometricBounds[2]) > bottomRightY) {
+                    bottomRightY = Number(frame.geometricBounds[2]);
                 }
             }
         }
@@ -538,23 +544,36 @@ class ExportInDesignArticlesToFolder {
      * @returns {IDD.TextFrame[]} All threaded text frames, including the starting frame.
      */
     #getThreadedFrames (textFrame) {
-        let threadedFrames = [];
-        let currentFrame = textFrame;
+        let threadedFrames = [textFrame];
 
         // Traverse forward through the thread chain
-        while (currentFrame) {
-            threadedFrames.push(currentFrame);
-            currentFrame = currentFrame.nextTextFrame;
+        /** @type {TextFrame | TextPath | NothingEnum} */
+        let threadedSibling = textFrame.nextTextFrame;
+        while (this.#isThreadedSiblingValidTextFrame(threadedSibling)) {
+            threadedFrames.push(threadedSibling); // append at end
+            threadedSibling = threadedSibling.nextTextFrame;
         }
 
         // Traverse backward through the thread chain
-        currentFrame = textFrame.previousTextFrame;
-        while (currentFrame) {
-            threadedFrames.unshift(currentFrame);
-            currentFrame = currentFrame.previousTextFrame;
+        threadedSibling = textFrame.previousTextFrame;
+        while (this.#isThreadedSiblingValidTextFrame(threadedSibling)) {
+            threadedFrames.unshift(threadedSibling); // insert at start
+            threadedSibling = threadedSibling.previousTextFrame;
         }
 
         return threadedFrames;
+    }
+
+    /**
+     * @param {TextFrame | TextPath | NothingEnum} threadedSibling
+     * @returns {threadedSibling is IDD.TextFrame}
+     */
+    #isThreadedSiblingValidTextFrame (threadedSibling) {
+        if (!threadedSibling || threadedSibling.constructorName !== "TextFrame") {
+            return false;
+        }
+        const textFrame = /** @type {TextFrame} */(threadedSibling);
+        return this.#inDesignArticleService.isValidTextFrame(textFrame);
     }
 
     /**
@@ -602,11 +621,13 @@ class ExportInDesignArticlesToFolder {
 
         // Calculate line height based on line leading and base shift of first character.
         let leading = line.leading; // line spacing
-        const baselineShift = line.characters.item(0).baselineShift;
+        const baselineShift = Number(line.characters.item(0).baselineShift);
 
         // If leading is set to Auto (value = -1), estimate it as 120% of font size.
-        if (typeof leading === "object" && leading.equals(idd.Leading.AUTO)) {
-            const fontSize = line.characters.item(0).pointSize;
+        if (leading !== null
+            && typeof leading === "object"
+            && (/** @type {object} */(leading)).equals(idd.Leading.AUTO)) {
+            const fontSize = Number(line.characters.item(0).pointSize);
             leading = fontSize * 1.2;
         }
 

--- a/ArticleShapeExtractor/modules/FileUtils.cjs
+++ b/ArticleShapeExtractor/modules/FileUtils.cjs
@@ -2,9 +2,9 @@ class FileUtils {
 
     /**
      * Creates a subfolder under a given parent folder. Returns the subfolder if already exists.
-     * @param {UXP.Folder} parentFolder
+     * @param {UXP.storage.Folder} parentFolder
      * @param {string} subfolderName
-     * @returns {{entry: UXP.Folder, created: boolean}}
+     * @returns {Promise<{entry: UXP.storage.Folder, created: boolean}>}
      */
     async getOrCreateSubFolder (parentFolder, subfolderName) {
         try {
@@ -17,9 +17,9 @@ class FileUtils {
 
     /**
      * Creates a file in a given folder. Returns the file if already exists.
-     * @param {UXP.Folder} folder
+     * @param {UXP.storage.Folder} folder
      * @param {string} filename
-     * @returns {{entry: UXP.File, created: boolean}}
+     * @returns {Promise<{entry: UXP.storage.File, created: boolean}>}
      */
     async getOrCreateFile (folder, filename) {
         try {

--- a/ArticleShapeExtractor/modules/FitArticleWithAIService.cjs
+++ b/ArticleShapeExtractor/modules/FitArticleWithAIService.cjs
@@ -52,7 +52,7 @@ class FitArticleWithAIService {
         // Resolve brand and section from layout doc (or use fallback settings).
         const { brand, section } = this.#brandSectionResolver.resolve(doc);
 
-        /*const pubInfos =*/ await this.#studioJsonRpcClient.getPublicationInfos([brand.id]);
+        /*const pubInfos =*/ await this.#studioJsonRpcClient.getPublicationInfos([brand.id], null);
         const accessToken = await this.#studioJsonRpcClient.getAccessToken(brand.id);
         /*const dimensions =*/ await this.#plaService.getSheetDimensions(accessToken, brand.id);
         // TODO: Error when layout does not occur in any of the dimensions.
@@ -68,7 +68,7 @@ class FitArticleWithAIService {
      * @param {string} accessToken
      * @param {BrandInfo} brand
      * @param {SectionInfo} section
-     * @returns {UXP.File[]}
+     * @returns {Promise<UXP.storage.File[]>}
      */
     async #retrieveArticleShapeSuggestions (accessToken, brand, section) {
         // TODO: Take values from extracted shape instead (to compose the request body).
@@ -92,7 +92,7 @@ class FitArticleWithAIService {
         const articleShapeFiles = [];
         for (const downloadUrl of downloadUrls) {
             const response = await fetch(downloadUrl);
-            const articleShapeJson = await response.json();
+            const articleShapeJson = /** @type {ArticleShapeJson} */(await response.json());
             const articleShapeFile = await this.#writeArticleJsonToTemp(articleShapeJson);
             this.#logger.debug(`Wrote article shape JSON into '${articleShapeFile.nativePath}'.`);
             articleShapeFiles.push(articleShapeFile);
@@ -103,9 +103,10 @@ class FitArticleWithAIService {
     /**
      * Create a new file in the temp folder and write the provided JSON data into it.
      * @param {ArticleShapeJson} articleJson
-     * @returns {UXP.File}
+     * @returns {Promise<UXP.storage.File>}
      */
     async #writeArticleJsonToTemp (articleJson) {
+        /** @type {UXP.storage.FileSystemProvider} */
         const lfs = require("uxp").storage.localFileSystem;
         const formats = require("uxp").storage.formats;
 

--- a/ArticleShapeExtractor/modules/GenreResolver.cjs
+++ b/ArticleShapeExtractor/modules/GenreResolver.cjs
@@ -77,7 +77,7 @@ class GenreResolver {
      * If the file already exists, it validates whether the genres to save are the same
      * as the genres in the file, which is expected.
      *
-     * @param {UXP.Folder} exportFolder
+     * @param {UXP.storage.Folder} exportFolder
      */
     async saveGenesToManifest (exportFolder) {
         const manifestFoldername = "_manifest";

--- a/ArticleShapeExtractor/modules/InDesignArticleService.cjs
+++ b/ArticleShapeExtractor/modules/InDesignArticleService.cjs
@@ -18,7 +18,8 @@ class InDesignArticleService {
             throw new Errors.NoDocumentOpenedError();
         }
 
-        if (idd.app.selection.length === 0) {
+        const selection = /** @type {object[]} */(idd.app.selection);
+        if (selection.length === 0) {
             throw new Errors.NoFramesSelectedError();
         }
 
@@ -102,9 +103,11 @@ class InDesignArticleService {
      * @returns {boolean} - True if the frame is already a member of the article, false otherwise.
      */
     #isFrameMemberOfInDesignArticle (article, frame) {
-        const articleMembers = article.articleMembers.everyItem().getElements(); // Get all members as an array
-        for (let i = 0; i < articleMembers.length; i++) {
-            if (articleMembers[i].itemRef.equals(frame)) {
+        const articleMembers = /** @type {IDD.ArticleMember} */
+            (/** @type {unknown} */(article.articleMembers.everyItem()));
+        const elements = articleMembers.getElements();
+        for (let i = 0; i < elements.length; i++) {
+            if (elements[i].itemRef.equals(frame)) {
                 return true; // The frame is already a member of the article
             }
         }
@@ -123,8 +126,9 @@ class InDesignArticleService {
         article.name = articleName;
 
         // Add selected frames to the new article.
-        for (let i = 0; i < idd.app.selection.length; i++) {
-            const frame = idd.app.selection[i];
+        const selection = /** @type {object[]} */(idd.app.selection);
+        for (let i = 0; i < selection.length; i++) {
+            const frame = selection[i];
             if (this.isValidArticleComponentFrame(frame)) {
                 try {
                     article.articleMembers.add(frame);
@@ -172,17 +176,20 @@ class InDesignArticleService {
     /**
      * Tells whether the given page item is a valid text frame (to be part of an article).
      * @param {IDD.PageItem|null} pageItem
-     * @returns {boolean}
+     * @returns {pageItem is IDD.TextFrame}
      */
     isValidTextFrame (pageItem) {
-        return this.#isValidFrameOfType(pageItem, ["TextFrame"])
-            && pageItem.contentType.toString() === idd.ContentType.TEXT_TYPE.toString();
+        if (!this.#isValidFrameOfType(pageItem, ["TextFrame"])) {
+            return false;
+        }
+        const textFrame = /** @type {IDD.TextFrame} */(pageItem);
+        return textFrame.contentType.toString() === idd.ContentType.TEXT_TYPE.toString();
     }
 
     /**
      * Tells whether the given page item is a valid graphic frame (to be part of an article).
      * @param {IDD.PageItem|null} pageItem
-     * @returns {boolean}
+     * @returns {pageItem is IDD.Oval | IDD.Polygon | IDD.Rectangle | IDD.GraphicLine}
      */
     isValidGraphicFrame (pageItem) {
         //Note: In the future we might want to extend with idd.ContentType.GRAPHIC_TYPE.toString()
@@ -194,7 +201,7 @@ class InDesignArticleService {
      * Tells whether the given page item is a Rectangle graphic frame, but very slim, hence
      * should be interpreted as a work-around of the layouter to compose a line (GraphicLine).
      * @param {IDD.PageItem|null} pageItem
-     * @returns {boolean}
+     * @returns {pageItem is IDD.Rectangle}
      */
     #isValid1DRectangleFrame (pageItem) {
         //Note: In the future we might want to extend with idd.ContentType.GRAPHIC_TYPE.toString()
@@ -202,8 +209,8 @@ class InDesignArticleService {
         if (!this.#isValidFrameOfType(pageItem, ["Rectangle"])) {
             return false;
         }
-        const width = pageItem.geometricBounds[3] - pageItem.geometricBounds[1];
-        const height = pageItem.geometricBounds[2] - pageItem.geometricBounds[0];
+        const width = Number(pageItem.geometricBounds[3]) - Number(pageItem.geometricBounds[1]);
+        const height = Number(pageItem.geometricBounds[2]) - Number(pageItem.geometricBounds[0]);
         const isVerySimilarToGraphicLine = height <= 10 || width <= 10;
         return isVerySimilarToGraphicLine;
     }
@@ -214,7 +221,7 @@ class InDesignArticleService {
      * These frames are included in "article definition" files (IDMS) but they
      * are excluded from "article composition" (JSON) files.
      * @param {IDD.PageItem|null} pageItem
-     * @returns {boolean}
+     * @returns {pageItem is IDD.GraphicLine}
      */
     isValid1DGraphicFrame (pageItem) {
         //Note: In the future we might want to extend with idd.ContentType.GRAPHIC_TYPE.toString()
@@ -228,7 +235,7 @@ class InDesignArticleService {
      * This includes Oval and Polygon frames, and Rectangle frames when not too slim.
      * This excludes TextFrame, GraphicLine and very slim Rectangle frames.
      * @param {IDD.PageItem|null} pageItem
-     * @returns {boolean}
+     * @returns {pageItem is IDD.Oval | IDD.Polygon}
      */
     isValid2DGraphicFrame (pageItem) {
         //Note: In the future we might want to extend with idd.ContentType.GRAPHIC_TYPE.toString()

--- a/ArticleShapeExtractor/modules/Logger.cjs
+++ b/ArticleShapeExtractor/modules/Logger.cjs
@@ -11,7 +11,7 @@ class Logger {
     /** @type {string} */
     #name;
 
-    /** @type {string} */
+    /** @type {number} */
     #level;
 
     /** @type {boolean} */
@@ -45,11 +45,10 @@ class Logger {
      * @param {string} message
      * @param {string|Object} [replacements] Can take any number of replacements, to be passed along to str.format()
      */
-    debug () {
+    debug (message, ...replacements) {
         if (!this.isDebug())
             return;
-        const args = Array.prototype.slice.call(arguments);
-        this.#log(5, args);
+        this.#log(5, [message, ...replacements]);
     };
 
     /**
@@ -64,11 +63,10 @@ class Logger {
      * @param {string} message
      * @param {string|Object} [replacements] Can take any number of replacements, to be passed along to str.format()
      */
-    info () {
+    info (message, ...replacements) {
         if (!this.isInfo())
             return;
-        const args = Array.prototype.slice.call(arguments);
-        this.#log(4, args);
+        this.#log(4, [message, ...replacements]);
     };
 
     /**
@@ -83,11 +81,10 @@ class Logger {
      * @param {string} message
      * @param {string|Object} [replacements] Can take any number of replacements, to be passed along to str.format()
      */
-    warning () {
+    warning (message, ...replacements) {
         if (!this.isWarning())
             return;
-        const args = Array.prototype.slice.call(arguments);
-        this.#log(3, args);
+        this.#log(3, [message, ...replacements]);
     };
 
     /**
@@ -102,11 +99,10 @@ class Logger {
      * @param {string} message
      * @param {string|Object} [replacements] Can take any number of replacements, to be passed along to str.format()
      */
-    error () {
+    error (message, ...replacements) {
         if (!this.isError())
             return;
-        const args = Array.prototype.slice.call(arguments);
-        this.#log(2, args);
+        this.#log(2, [message, ...replacements]);
     };
 
     /**
@@ -121,11 +117,10 @@ class Logger {
      * @param {string} message
      * @param {string|Object} [replacements] Can take any number of replacements, to be passed along to str.format()
      */
-    critical () {
+    critical (message, ...replacements) {
         if (!this.isCritical())
             return;
-        const args = Array.prototype.slice.call(arguments);
-        this.#log(1, args);
+        this.#log(1, [message, ...replacements]);
     };
 
     /**
@@ -136,8 +131,8 @@ class Logger {
     }
 
     /**
-     * @param {string} logLevel
-     * @param {string} args
+     * @param {number} logLevel
+     * @param {(string|Object|undefined)[]} args
      */
     #log (logLevel, args) {
         const template = args.shift();
@@ -154,7 +149,7 @@ class Logger {
     };
 
     /**
-     * @param {string} logLevel
+     * @param {number} logLevel
      * @param {string} message
      */
     #writeLine (logLevel, message) {

--- a/ArticleShapeExtractor/modules/PageLayoutSettings.cjs
+++ b/ArticleShapeExtractor/modules/PageLayoutSettings.cjs
@@ -1,4 +1,5 @@
 const idd = require("indesign");
+/** @type {UXP.storage.FileSystemProvider} */
 const lfs = require("uxp").storage.localFileSystem;
 const formats = require("uxp").storage.formats;
 const Errors = require("./Errors.cjs");
@@ -28,8 +29,8 @@ class PageLayoutSettings {
      * "_manifest/page-layout-settings.json" in the given folder. When this file
      * already exists, the settings are compared instead.
      * @param {IDD.Document} doc
-     * @param {UXP.Folder} folder
-     * @returns {boolean} True when the settings are matching (or new), false otherwise.
+     * @param {UXP.storage.Folder} folder
+     * @returns {Promise<boolean>} True when the settings are matching (or new), false otherwise.
      */
     async exportSettings (doc, folder) {
         let exportedSuccessfully = false;
@@ -70,7 +71,7 @@ class PageLayoutSettings {
      * @param {IDD.Document} doc
      * @param {Page} page
      * @param {number} baselineStart
-     * @returns {{dimensions: {width: number, height: number}, margins: {top: number, bottom: number, inside: number, outside: number}, columns: {gutter: number}}
+     * @returns {PageLayoutSettingsDto}
      */
     #composeSettings (doc, page, baselineStart) {
         return {
@@ -96,11 +97,11 @@ class PageLayoutSettings {
 
     /**
      * Round a given number to a precision of maximum 3 decimals.
-     * @param {number} precisionNumber
+     * @param {number|string} precisionNumber
      * @returns {number}
      */
     #roundTo3Decimals (precisionNumber) {
-        return Math.round(precisionNumber * 1000) / 1000;
+        return Math.round(Number(precisionNumber) * 1000) / 1000;
     }
 
     /**
@@ -111,11 +112,11 @@ class PageLayoutSettings {
      * @returns number Baseline start (always relative to top of page).
      */
     #getBaselineStart (doc, page) {
-        let baselineStart = doc.gridPreferences.baselineStart;
+        let baselineStart = Number(doc.gridPreferences.baselineStart);
         const isGridRelativeToPageMargins = doc.gridPreferences.baselineGridRelativeOption.equals(
             idd.BaselineGridRelativeOption.TOP_OF_MARGIN_OF_BASELINE_GRID_RELATIVE_OPTION);
         if (isGridRelativeToPageMargins) {
-            baselineStart += page.marginPreferences.top;
+            baselineStart += Number(page.marginPreferences.top);
             this.#logger.debug(
                 "Baseline start is configured as relative to top margin, but exported as relative to top of page: "
                 + `${doc.gridPreferences.baselineStart} (=start) + ${page.marginPreferences.top} (=top margin) = ${baselineStart}`,
@@ -139,8 +140,8 @@ class PageLayoutSettings {
      * rather unimportant to be the same across all layouts of the section. Reason is that an article taken from source
      * layout A will perfectly be placed on target layout B while their margins/dimensions are not exactly matching.
      *
-     * @param {{dimensions: {width: number, height: number}, margins: {top: number, bottom: number, inside: number, outside: number}, columns: {gutter: number}} settings
-     * @param {UXP.Folder} exportFolder
+     * @param {PageLayoutSettingsDto} settings
+     * @param {UXP.storage.Folder} exportFolder
      */
     async #saveOrComparePageLayoutSettings (settings, exportFolder) {
         const manifestFoldername = "_manifest";
@@ -172,9 +173,9 @@ class PageLayoutSettings {
 
     /**
      * Compares the columns gutter and baseline grid increments properties of the page layout settings.
-     * @param {PageLayoutSettings} lhsSettings
-     * @param {PageLayoutSettings} rhsSettings
-     * @returns {{propertyPath: string, lhsValue: Any, rhsValue: Any}|null} A property that differs, null otherwise.
+     * @param {PageLayoutSettingsDto} lhsSettings
+     * @param {PageLayoutSettingsDto} rhsSettings
+     * @returns {{propertyPath: string, lhsValue: any, rhsValue: any}|null} A property that differs, null otherwise.
      */
     #diffInDesignPageLayoutGrid (lhsSettings, rhsSettings) {
         const pathsToCompare = [
@@ -194,9 +195,9 @@ class PageLayoutSettings {
 
     /**
      * Resolves the value of a property (path) in a deeply nested DTO (obj).
-     * @param {PageLayoutSettings} obj
+     * @param {PageLayoutSettingsDto} obj
      * @param {string} path
-     * @returns {Any}
+     * @returns {any}
      */
     #getPropertyValueByPath (obj, path) {
         return path.split(".").reduce((acc, key) => acc?.[key], obj);

--- a/ArticleShapeExtractor/modules/PlaService.cjs
+++ b/ArticleShapeExtractor/modules/PlaService.cjs
@@ -30,12 +30,11 @@ class PlaService {
      * Those are set once blueprints are configured.
      * @param {string} accessToken
      * @param {string} brandId
-     * @returns {Object[]} List of sheet dimension DTOs.
+     * @returns {Promise<Object[]>} List of sheet dimension DTOs.
      */
     async getSheetDimensions (accessToken, brandId) {
         const url = `${this.#plaServiceUrl}/brands/${brandId}/sheet-dimensions`;
-        /** @type {UXP.Request} */
-        const httpRequest = new Request(url, this.#requestInitForPlaService(accessToken, "GET"));
+        const httpRequest = new globalThis.Request(url, this.#requestInitForPlaService(accessToken, "GET"));
         try {
             const jsonResponseBody = await this.#fetchJson(httpRequest, null);
             this.#logger.info(`Retrieved ${jsonResponseBody.length} sheet dimensions.`);
@@ -49,7 +48,7 @@ class PlaService {
     /**
      * @param {UXP.Request} httpRequest
      * @param {Object|null} jsonRequestBody JSON request body
-     * @returns {Object} JSON response body.
+     * @returns {Promise<Object>} JSON response body.
      */
     async #fetchJson (httpRequest, jsonRequestBody) {
         let httpResponse = null;
@@ -150,7 +149,7 @@ class PlaService {
      * @param {string} brandId
      * @param {string} sectionId
      * @param {Object} jsonRequestBody
-     * @returns {string[]} List of download URLs of the suggested article JSON files.
+     * @returns {Promise<string[]>} List of download URLs of the suggested article JSON files.
      */
     async suggestArticleShapes (accessToken, brandId, sectionId, jsonRequestBody) {
         const url = `${this.#plaServiceUrl}/brands/${brandId}/sections/${sectionId}/suggest-article-shapes`

--- a/ArticleShapeExtractor/modules/PreferencesManager.cjs
+++ b/ArticleShapeExtractor/modules/PreferencesManager.cjs
@@ -1,18 +1,18 @@
 class PreferencesManager {
 
-    /** @type {IDD.Preference} */
+    /** @type {Object} */
     #appPreferences;
 
     /**
-     * @param {IDD.Preference} appPreferences
+     * @param {Object} appPreferences
      */
     constructor (appPreferences) {
         this.#appPreferences = appPreferences;
     }
 
     /**
-     * @param {IDD.Preference} updates Preferences to adjust.
-     * @returns {IDD.Preference} Original preferences.
+     * @param {Object} updates Preferences to adjust.
+     * @returns {Object} Original preferences.
      */
     overridePreferences (updates) {
         const originalPreferences = {};
@@ -24,7 +24,7 @@ class PreferencesManager {
     };
 
     /**
-     * @param {IDD.Preference} originalPreferences
+     * @param {Object} originalPreferences
      */
     restoreOriginalPreferences (originalPreferences) {
         for (const key in originalPreferences) {

--- a/ArticleShapeExtractor/modules/RegenerateArticleShapesService.cjs
+++ b/ArticleShapeExtractor/modules/RegenerateArticleShapesService.cjs
@@ -12,7 +12,7 @@ class RegenerateArticleShapesService {
     /** @type {VersionUtils} */
     #versionUtils;
 
-    /** @type {{{brand: string, issue: string, category: string, status: string}, layoutStatusOnSuccess: string, layoutStatusOnError: string}} */
+    /** @type {{filter: {brand: string, issue: string, category: string, status: string}, layoutStatusOnSuccess: string, layoutStatusOnError: string}} */
     #settings;
 
     /** @type {ExportInDesignArticlesToFolder} */
@@ -30,7 +30,7 @@ class RegenerateArticleShapesService {
     /**
      * @param {Logger} logger
      * @param {VersionUtils} versionUtils
-     * @param {{{brand: string, issue: string, category: string, status: string}, layoutStatusOnSuccess: string, layoutStatusOnError: string}} settings
+     * @param {{filter: {brand: string, issue: string, category: string, status: string}, layoutStatusOnSuccess: string, layoutStatusOnError: string}} settings
      * @param {ExportInDesignArticlesToFolder} exportInDesignArticlesToFolder
      * @param {StudioJsonRpcClient} studioJsonRpcClient
      */
@@ -49,7 +49,7 @@ class RegenerateArticleShapesService {
      * opened (and closed) one-by-one and the placed article shape files are extracted to the given folder.
      * When a shape files already exist for a certain layout id and version, that layout is skipped for performance
      * optimization. All processed layouts (regardless whether skipped) are sent to their next status in the workflow.
-     * @param {UXP.Folder} folder
+     * @param {UXP.storage.Folder} folder
      */
     async run (folder) {
 
@@ -77,7 +77,7 @@ class RegenerateArticleShapesService {
      * Process queried layout objects, compare against disk state, export if needed.
      * @param {Object[]} wflObjects Workflow layout objects.
      * @param {Map<string,{layoutVersion:string,shapeFiles:File[]}>} fileMap Indexed by layout ids.
-     * @param {UXP.Folder} folder Target folder for exporting.
+     * @param {UXP.storage.Folder} folder Target folder for exporting.
      * @param {{extracted: number, skipped: number, failed: number}} report
      */
     async #processQueriedLayouts (wflObjects, fileMap, folder, report) {
@@ -101,7 +101,7 @@ class RegenerateArticleShapesService {
                 }
                 const theOpenDoc = idd.app.openObject(wflObject.ID, false); // false: no checkout
                 const shapeCount = await this.#exportInDesignArticlesToFolder.run(theOpenDoc, folder);
-                theOpenDoc.close(idd.SaveOptions.no);
+                theOpenDoc.close(idd.SaveOptions.NO);
                 if (shapeCount > 0) {
                     extractedLayoutIds.push(wflObject.ID);
                 }
@@ -166,7 +166,7 @@ class RegenerateArticleShapesService {
     /**
      * Collect article shape files from a given folder and build a structure map.
      * Those files assumed to have a postfix "(<layout_id>.v<major>.<minor>).".
-     * @param {UXP.Folder} folder
+     * @param {UXP.storage.Folder} folder
      * @returns {Promise<Map<string,{layoutVersion:string,shapeFiles:UXP.File[]}>>} Structured map, indexed by layout id.
      */
     async #buildMapOfLayoutIdsVersionsAndFiles (folder) {
@@ -203,8 +203,8 @@ class RegenerateArticleShapesService {
 
     /**
      * Return a list of article shape files (from the given folder) having postfix "(<layout_id>.v<major>.<minor>).".
-     * @param {UXP.Folder} folder
-     * @returns {Promise<{shapeFile: UXP.File, layoutId: string, layoutVersion: string}[]>}
+     * @param {UXP.storage.Folder} folder
+     * @returns {Promise<{shapeFile: UXP.storage.File, layoutId: string, layoutVersion: string}[]>}
      */
     async #filterArticleShapeFiles (folder) {
         const entriesInFolder = await folder.getEntries();
@@ -239,7 +239,7 @@ class RegenerateArticleShapesService {
 
     /**
      * Remove a file from disk. Log warning on failure.
-     * @param {UXP.File} file
+     * @param {UXP.storage.File} file
      */
     async #deleteFile (file) {
         this.#logger.debug(`Deleting file: ${file.name}`);

--- a/ArticleShapeExtractor/modules/Settings.cjs
+++ b/ArticleShapeExtractor/modules/Settings.cjs
@@ -25,7 +25,7 @@ class Settings {
     }
 
     /**
-     * @returns {{{brand: string, issue: string, category: string, status: string}, layoutStatusOnSuccess: string, layoutStatusOnError: string}}
+     * @returns {{filter: {brand: string, issue: string, category: string, status: string}, layoutStatusOnSuccess: string, layoutStatusOnError: string}}
      */
     getRegenerateArticleShapesSettings () {
         const settings = this.#configData.regenerateArticleShapesSettings;

--- a/ArticleShapeExtractor/modules/StudioJsonRpcClient.cjs
+++ b/ArticleShapeExtractor/modules/StudioJsonRpcClient.cjs
@@ -46,7 +46,7 @@ class StudioJsonRpcClient {
      * Call the GetPublications workflow service provided by Studio Server.
      * @param {string[]|null} brandIds List of ids, or null for all brands.
      * @param {string[]|null} requestInfo Brand setup info to resolve: "FeatureAccessList", "ObjectTypeProperties", "ActionProperties", "States", "CurrentIssue", "PubChannels", "Categories"
-     * @returns {Object[]} List of PublicationInfo data objects.
+     * @returns {Promise<Object[]>} List of PublicationInfo data objects.
      */
     async getPublicationInfos (brandIds, requestInfo) {
         const url = this.#getStudioServerUrl();
@@ -69,7 +69,7 @@ class StudioJsonRpcClient {
      * @param {string} url
      * @param {Object} request
      * @param {string} serviceName
-     * @returns {Object} Response
+     * @returns {Promise<Object>} Response
      */
     async #callWebService (url, request, serviceName) {
         this.#rpcSequenceId += 1;
@@ -111,7 +111,7 @@ class StudioJsonRpcClient {
     /**
      * @param {Request} httpRequest
      * @param {Object} rpcRequestBody JSON RPC request body.
-     * @returns {Object} JSON RPC response body.
+     * @returns {Promise<Object>} JSON RPC response body.
      */
     async #fetchRpc (httpRequest, rpcRequestBody) {
         let httpResponse = null;
@@ -182,7 +182,7 @@ class StudioJsonRpcClient {
      * @param {Object[]} searchParams List of QueryParam objects.
      * @param {string[]} resolveProperties List of workflow object property names to resolve.
      * @param {number} firstEntry Object index to start reading from (in paged results).
-     * @returns {Object} QueryObjectsResponse
+     * @returns {Promise<Object>} QueryObjectsResponse
      */
     async #queryObjectsOneResultPage (searchParams, resolveProperties, firstEntry) {
         const startsWithProps = ["ID", "Type", "Name"]; // service rule: must start with this sequence of props
@@ -252,7 +252,7 @@ class StudioJsonRpcClient {
     /**
      * Retrieve a new access token that can be used for WW cloud services.
      * @param {string} brandId
-     * @returns {string}
+     * @returns {Promise<string>}
      */
     async getAccessToken (brandId) {
         const url = this.#getStudioClientServerPluginUrl();

--- a/ArticleShapeExtractor/package-lock.json
+++ b/ArticleShapeExtractor/package-lock.json
@@ -14,6 +14,7 @@
         "@stylistic/eslint-plugin": "^5.6.1",
         "eslint": "^9.39.2",
         "globals": "^16.5.0",
+        "types-for-adobe": "^7.2.5",
         "typescript": "^5.9.3"
       }
     },
@@ -1093,6 +1094,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/types-for-adobe": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/types-for-adobe/-/types-for-adobe-7.2.5.tgz",
+      "integrity": "sha512-QUoHmjFbA/g+DnFMYwcNcGczDgcPmbtIYcmfDQZEUmtLK51W91BUlyMOdRUyuxQ8VjNuvROAjbORCz8iaML4hg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/ArticleShapeExtractor/package.json
+++ b/ArticleShapeExtractor/package.json
@@ -17,6 +17,7 @@
     "@stylistic/eslint-plugin": "^5.6.1",
     "eslint": "^9.39.2",
     "globals": "^16.5.0",
+    "types-for-adobe": "^7.2.5",
     "typescript": "^5.9.3"
   }
 }

--- a/ArticleShapeExtractor/types.dto.d.js
+++ b/ArticleShapeExtractor/types.dto.d.js
@@ -46,3 +46,36 @@
  * @property {string} id
  * @property {string} name
  */
+
+/**
+ * @typedef {Object} PageLayoutSettingsDto
+ * @property {PageLayoutDimensions} dimensions
+ * @property {PageLayoutMargins} margins
+ * @property {PageLayoutColumns} columns
+ * @property {PageLayoutBaselineGrid} baseline-grid
+ */
+
+/**
+ * @typedef {Object} PageLayoutDimensions
+ * @property {number} width
+ * @property {number} height
+ */
+
+/**
+ * @typedef {Object} PageLayoutMargins
+ * @property {number} top
+ * @property {number} bottom
+ * @property {number} inside
+ * @property {number} outside
+ */
+
+/**
+ * @typedef {Object} PageLayoutColumns
+ * @property {number} gutter
+ */
+
+/**
+ * @typedef {Object} PageLayoutBaselineGrid
+ * @property {number} start
+ * @property {number} increment
+ */

--- a/ArticleShapeExtractor/types/indesign-aliases.d.ts
+++ b/ArticleShapeExtractor/types/indesign-aliases.d.ts
@@ -1,16 +1,42 @@
-declare namespace IDD { 
-  type Application = globalThis.Application;
-  type Article = globalThis.Article;
-  type ArticleMember = globalThis.ArticleMember;
-  type Element = globalThis.Element;
-  type Document = globalThis.Document;
-  type Line = globalThis.Line;
-  type Page = globalThis.Page;
-  type PageItem = globalThis.PageItem;
-  type Preference = globalThis.Preference;
-  type TextFrame = globalThis.TextFrame;
-}
+/// <reference types="types-for-adobe/InDesign/2023" />
 
-declare module "indesign" {
-  export const app: IDD.Application;
+export {};
+
+declare global {
+  declare namespace IDD { 
+    type Application = globalThis.Application;
+    type Article = globalThis.Article;
+    type ArticleMember = globalThis.ArticleMember;
+    type ArticleMembers = globalThis.ArticleMembers;
+    type Document = globalThis.Document;
+    type Element = globalThis.Element;
+    type GraphicLine = globalThis.GraphicLine;
+    type Line = globalThis.Line;
+    type Oval = globalThis.Oval;
+    type Page = globalThis.Page;
+    type PageItem = globalThis.PageItem;
+    type Polygon = globalThis.Polygon;
+    type Preference = globalThis.Preference;
+    type Rectangle = globalThis.Rectangle;
+    type TextFrame = globalThis.TextFrame;
+
+    // enums/constants
+    type AutoEnum = typeof AutoEnum;
+    type BaselineGridRelativeOption = typeof BaselineGridRelativeOption;
+    type ContentType = typeof ContentType;
+    type ExportFormat = typeof ExportFormat;
+    type JPEGOptionsQuality = typeof JPEGOptionsQuality;
+    type JPEGOptionsFormat = typeof JPEGOptionsFormat;
+    type JpegColorSpaceEnum = typeof JpegColorSpaceEnum;
+    type Leading = typeof Leading;
+    type MeasurementUnits = typeof MeasurementUnits;
+    type PageSideOptions = typeof PageSideOptions;
+    type SaveOptions = typeof SaveOptions;
+    type TextWrapModes = typeof TextWrapModes;
+  }
+
+  interface Object {
+    constructorName: string;
+    equals(other: any): boolean;
+  }
 }

--- a/ArticleShapeExtractor/types/indesign-module.d.ts
+++ b/ArticleShapeExtractor/types/indesign-module.d.ts
@@ -1,0 +1,19 @@
+/// <reference types="types-for-adobe/InDesign/2023" />
+
+declare module "indesign" {
+  export const idd: IDD;
+  export const app: IDD.Application;
+
+  export const AutoEnum: IDD.AutoEnum;
+  export const BaselineGridRelativeOption: IDD.BaselineGridRelativeOption;
+  export const ContentType: IDD.ContentType;
+  export const ExportFormat: IDD.ExportFormat;
+  export const JPEGOptionsQuality: IDD.JPEGOptionsQuality;
+  export const JPEGOptionsFormat: IDD.JPEGOptionsFormat;
+  export const JpegColorSpaceEnum: IDD.JpegColorSpaceEnum;
+  export const Leading: IDD.Leading;
+  export const MeasurementUnits: IDD.MeasurementUnits;
+  export const PageSideOptions: IDD.PageSideOptions
+  export const SaveOptions: IDD.SaveOptions;
+  export const TextWrapModes: IDD.TextWrapModes;
+}

--- a/ArticleShapeExtractor/types/indesign-ww-plugin.d.ts
+++ b/ArticleShapeExtractor/types/indesign-ww-plugin.d.ts
@@ -1,0 +1,63 @@
+/// <reference types="types-for-adobe/InDesign/2023" />
+
+export {};
+
+/**
+ * The InDesign script API is extended by the WoodWing Studio plugins for InDesign.
+ * In the below only those properties that used by our tool are defined.
+ */
+declare global {
+  interface PageItem {
+    /**
+     * See https://woodwing.github.io/enterprise-integration-guide/1237-elementLabel
+     */
+    elementLabel?: string;
+  }
+
+  interface Document {
+    entMetaData: {
+      /**
+       * See https://woodwing.github.io/enterprise-integration-guide/1223-get
+       * 
+       * @param {string} key
+       * @returns {string}
+       */
+      get(key);
+    }
+  }
+
+  interface Application {
+    entSession: {
+      /**
+       * See https://woodwing.github.io/enterprise-integration-guide/1211-getPublication
+       * 
+       * @param publicationId
+       * @returns {BrandInfo}
+       */
+      getPublication(publicationId);
+
+      /**
+       * See https://woodwing.github.io/enterprise-integration-guide/1208-getCategory
+       * 
+       * @param {string} publicationId
+       * @param {string} sectionId
+       * @param {string} [issueId]
+       * @returns {SectionInfo} 
+       */
+      getCategory (publicationId, sectionId, issueId);
+    }
+
+    /**
+     * See https://woodwing.github.io/enterprise-integration-guide/1082-openObject
+     * 
+     * @param {string} objectId
+     * @param {boolean} [checkout]
+     * @param {boolean} [withWindow]
+     * @param {string} [type]
+     * @param {string} [dossierId]
+     * @param {string} [server]
+     * @returns {Object}
+     */
+    openObject(objectId, checkout, withWindow, type, dossierId, server);
+  }
+}

--- a/ArticleShapeExtractor/types/string-extensions.d.ts
+++ b/ArticleShapeExtractor/types/string-extensions.d.ts
@@ -1,0 +1,21 @@
+export {};
+
+declare global {
+  interface String {
+    /**
+     * Remove characters or whitespaces from the start of string.
+     */
+    ltrim(characters?: string): string;
+
+    /**
+     * Remove characters or whitespaces from the end of string.
+     */
+    rtrim(characters?: string): string;
+
+    /**
+     * Escape regex special characters.
+     * @internal
+     */
+    _escapeRegExChars(characters: string): string;
+  }
+}

--- a/ArticleShapeExtractor/types/uxp-aliases.d.ts
+++ b/ArticleShapeExtractor/types/uxp-aliases.d.ts
@@ -1,7 +1,23 @@
-declare namespace UXP {
-  type File = import("uxp").storage.File;
-  type Folder = import("uxp").storage.Folder;
-  type Headers = globalThis.Headers;
-  type Request = globalThis.Request;
-  type Response = globalThis.Response;
+/// <reference types="@adobe/cc-ext-uxp-types" />
+
+export {};
+
+declare global {
+  namespace UXP {  
+    namespace storage {
+      type File = import("uxp").storage.File;
+      type FileSystemProvider = import("uxp").storage.FileSystemProvider;
+      type Folder = import("uxp").storage.Folder;
+    }
+
+    type Path = import("uxp").Path;
+    type Headers = globalThis.Headers;
+    type Request = globalThis.Request;
+    type Response = globalThis.Response;
+  }
+
+  const window: {
+    path: UXP.Path;
+  }
 }
+

--- a/ArticleShapeExtractor/types/uxp-module.d.ts
+++ b/ArticleShapeExtractor/types/uxp-module.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="@adobe/cc-ext-uxp-types" />
+
+declare module "uxp" {
+    namespace storage {
+        export const localFileSystem: UXP.storage.FileSystemProvider;
+    }
+
+    export import Path = UXP.Path;
+}


### PR DESCRIPTION
Rather than linking to remote git repo, npm install the types-for-adobe to make the same as done for the uxp types. 
Only invoke the types/*.d.ts files and let them refer to the desired DOM version. 
Make the types files more complete. 
Add a types file for the scripting API that is extended by the SC plugins for InDesign. 
Prepare the codebase for the jsCheck option, but I could not solve all, so left it false for now. 
Because quite some InDesign types are "number | string" there is a need to cast them to Number(...) before using.