### PR TITLE
LA-224 AI fitting - step 9 - Rename idd into ind

### DIFF
--- a/.github/workflows/CI-article-shape-extractor.yml
+++ b/.github/workflows/CI-article-shape-extractor.yml
@@ -47,6 +47,5 @@ jobs:
       - name: Validate code and formatting
         run: npm run lint
 
-      # TODO: After solving problems, enable this step.
-      #- name: Type checking for JS code.
-      #  run: npm run typecheck
+      - name: Type checking for JS code.
+        run: npm run typecheck

--- a/.github/workflows/CI-article-shape-extractor.yml
+++ b/.github/workflows/CI-article-shape-extractor.yml
@@ -3,8 +3,8 @@ name: CI - Article Shape Extractor
 on:
   # Run the tests on pushes to these branches.
   push:
-  #  branches:
-  #    - master
+    branches:
+      - master
 
   # Run the tests on pushes to feature branches (PRs) that are targeting these branches.
   pull_request:

--- a/ArticleShapeExtractor/bootstrap.js
+++ b/ArticleShapeExtractor/bootstrap.js
@@ -114,13 +114,13 @@ Container.registerFactory("ExportInDesignArticlesToFolder", function () {
 });
 
 Container.registerFactory("StudioJsonRpcClient", function () {
-    const idd = require("indesign");
+    const ind = require("indesign");
     const StudioJsonRpcClient = require("./modules/StudioJsonRpcClient.cjs");
     return new StudioJsonRpcClient(
         Container.resolve("Logger"),
         Container.resolve("HttpLogger"),
-        idd.app.entSession?.activeUrl,
-        idd.app.entSession?.activeTicket,
+        ind.app.entSession?.activeUrl,
+        ind.app.entSession?.activeTicket,
     );
 });
 

--- a/ArticleShapeExtractor/commands/ExtractArticleShapes.idjs
+++ b/ArticleShapeExtractor/commands/ExtractArticleShapes.idjs
@@ -1,16 +1,16 @@
 await (async function main () {
-    const idd = require("indesign");
+    const ind = require("indesign");
     const initBootstrap = require("../bootstrap.js");
     const Container = require("../modules/Container.cjs");
     const Errors = require("../modules/Errors.cjs");
     try {
         initBootstrap();
 
-        if (idd.app.documents.length === 0) {
+        if (ind.app.documents.length === 0) {
             throw new Errors.NoDocumentOpenedError();
         }
 
-        const doc = idd.app.activeDocument;
+        const doc = ind.app.activeDocument;
         if (doc.articles.length === 0) {
             throw new Errors.NoArticlesInDocumentError();
         }

--- a/ArticleShapeExtractor/commands/FitArticleWithAI.idjs
+++ b/ArticleShapeExtractor/commands/FitArticleWithAI.idjs
@@ -1,16 +1,16 @@
 await (async function main () {
-    const idd = require("indesign");
+    const ind = require("indesign");
     const initBootstrap = require("../bootstrap.js");
     const Container = require("../modules/Container.cjs");
     const Errors = require("../modules/Errors.cjs");
     try {
         initBootstrap();
 
-        if (idd.app.documents.length === 0) {
+        if (ind.app.documents.length === 0) {
             throw new Errors.NoDocumentOpenedError();
         }
 
-        const doc = idd.app.activeDocument;
+        const doc = ind.app.activeDocument;
         if (doc.articles.length === 0) {
             throw new Errors.NoArticlesInDocumentError();
         }

--- a/ArticleShapeExtractor/commands/RegenerateArticleShapes.idjs
+++ b/ArticleShapeExtractor/commands/RegenerateArticleShapes.idjs
@@ -1,5 +1,5 @@
 await (async function main () {
-    const idd = require("indesign");
+    const ind = require("indesign");
     const initBootstrap = require("../bootstrap.js");
     const Container = require("../modules/Container.cjs");
     const Errors = require("../modules/Errors.cjs");
@@ -26,10 +26,10 @@ await (async function main () {
         await genreResolver.saveGenesToManifest(folder);
 
         // Export article shapes to disk.
-        idd.app.scriptPreferences.userInteractionLevel = idd.UserInteractionLevels.neverInteract;
+        ind.app.scriptPreferences.userInteractionLevel = ind.UserInteractionLevels.neverInteract;
         const regenerator = /** @type RegenerateArticleShapesService */(Container.resolve("RegenerateArticleShapesService"));
         const report = await regenerator.run(folder);
-        idd.app.scriptPreferences.userInteractionLevel = idd.UserInteractionLevels.interactWithAll;
+        ind.app.scriptPreferences.userInteractionLevel = ind.UserInteractionLevels.interactWithAll;
         const completedMessage = "Article Shapes are regenerated.";
         const reportMessage = `Extracted: ${report.extracted}, Skipped: ${report.skipped}, Failed: ${report.failed}.`;
         logger.info(`${completedMessage} => ${reportMessage}`);
@@ -38,7 +38,7 @@ await (async function main () {
     }
     catch (error) {
         // First enable the user interaction again to able to show the alert.
-        idd.app.scriptPreferences.userInteractionLevel = idd.UserInteractionLevels.interactWithAll;
+        ind.app.scriptPreferences.userInteractionLevel = ind.UserInteractionLevels.interactWithAll;
         logger.logError(error);
         alert(error.message);
     }

--- a/ArticleShapeExtractor/extensions/globals.js
+++ b/ArticleShapeExtractor/extensions/globals.js
@@ -5,8 +5,8 @@
  * @returns
  */
 globalThis.alert = function (msg, caption) {
-    const idd = require("indesign");
-    const theDialog = idd.app.dialogs.add({ name: caption || "Alert" });
+    const ind = require("indesign");
+    const theDialog = ind.app.dialogs.add({ name: caption || "Alert" });
     const col = theDialog.dialogColumns.add();
     const lines = ("" + msg).split("\n");
     for (const line of lines) {

--- a/ArticleShapeExtractor/modules/BrandSectionMapResolver.cjs
+++ b/ArticleShapeExtractor/modules/BrandSectionMapResolver.cjs
@@ -1,5 +1,3 @@
-const idd = require("indesign");
-
 /**
  * Understands how to obtain the id/name info for all brands and their categories
  * and how to provides that information in the _manifest subfolder of the export folder.

--- a/ArticleShapeExtractor/modules/BrandSectionResolver.cjs
+++ b/ArticleShapeExtractor/modules/BrandSectionResolver.cjs
@@ -1,4 +1,4 @@
-const idd = require("indesign");
+const ind = require("indesign");
 
 /**
  * Understands how to resolve the Brand and Section.
@@ -39,10 +39,10 @@ class BrandSectionResolver {
         let section = null;
         let source = null;
         try {
-            brand = idd.app.entSession.getPublication(
+            brand = ind.app.entSession.getPublication(
                 doc.entMetaData.get("Core_Publication"),
             );
-            section = idd.app.entSession.getCategory(
+            section = ind.app.entSession.getCategory(
                 doc.entMetaData.get("Core_Publication"),
                 doc.entMetaData.get("Core_Section"),
                 doc.entMetaData.get("Core_Issue"),

--- a/ArticleShapeExtractor/modules/BrandSectionResolver.cjs
+++ b/ArticleShapeExtractor/modules/BrandSectionResolver.cjs
@@ -31,7 +31,7 @@ class BrandSectionResolver {
     /**
      * When there is a valid session and the layout is stored in Studio, take the brand and section from
      * the layout, otherwise take the brand- and section fallback settings from the config files.
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      * @returns {{brand: BrandInfo, section: SectionInfo}}
      */
     resolve (doc) {

--- a/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.cjs
+++ b/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.cjs
@@ -1,4 +1,4 @@
-const idd = require("indesign");
+const ind = require("indesign");
 
 /**
  * Understands how to extract article shapes from InDesign Articles.
@@ -56,7 +56,7 @@ class ExportInDesignArticlesToFolder {
         const docName = doc.saved ? lfs.getNativePath(await doc.fullName) : doc.name;
         this.#logger.info("Extracting InDesign Articles for layout document '{}'.", docName);
 
-        idd.app.scriptPreferences.measurementUnit = idd.MeasurementUnits.POINTS;
+        ind.app.scriptPreferences.measurementUnit = ind.MeasurementUnits.POINTS;
         let exportCounter = 0;
         for (let articleIndex = 0; articleIndex < doc.articles.length; articleIndex++) {
             const article = doc.articles.item(articleIndex);
@@ -64,7 +64,7 @@ class ExportInDesignArticlesToFolder {
                 exportCounter++;
             }
         }
-        idd.app.scriptPreferences.measurementUnit = idd.AutoEnum.AUTO_VALUE;
+        ind.app.scriptPreferences.measurementUnit = ind.AutoEnum.AUTO_VALUE;
         return exportCounter;
     }
 
@@ -382,7 +382,7 @@ class ExportInDesignArticlesToFolder {
 
         // Export JPEG image.
         const PreferencesManager = require("./PreferencesManager.cjs");
-        const preferencesManager = new PreferencesManager(idd.app.jpegExportPreferences);
+        const preferencesManager = new PreferencesManager(ind.app.jpegExportPreferences);
         let originalPreferences = null;
         let group = null;
         let isExported = false;
@@ -392,17 +392,17 @@ class ExportInDesignArticlesToFolder {
                 antiAlias: true,
                 useDocumentBleeds: false,
                 simulateOverprint: false,
-                jpegQuality: idd.JPEGOptionsQuality.HIGH,
-                jpegRenderingStyle: idd.JPEGOptionsFormat.BASELINE_ENCODING,
+                jpegQuality: ind.JPEGOptionsQuality.HIGH,
+                jpegRenderingStyle: ind.JPEGOptionsFormat.BASELINE_ENCODING,
                 exportResolution: 144, // DPI, screen resolution
-                jpegColorSpace: idd.JpegColorSpaceEnum.RGB,
+                jpegColorSpace: ind.JpegColorSpaceEnum.RGB,
             });
             if (pageItems.length === 1) {
-                pageItems[0].exportFile(idd.ExportFormat.JPG, imgFile);
+                pageItems[0].exportFile(ind.ExportFormat.JPG, imgFile);
             }
             else {
                 group = doc.groups.add(pageItems);
-                group.exportFile(idd.ExportFormat.JPG, imgFile);
+                group.exportFile(ind.ExportFormat.JPG, imgFile);
             }
             isExported = true;
         }
@@ -589,19 +589,19 @@ class ExportInDesignArticlesToFolder {
 
         const textWrapPrefs = frame.textWrapPreferences;
 
-        if (textWrapPrefs.textWrapMode.equals(idd.TextWrapModes.NONE)) {
+        if (textWrapPrefs.textWrapMode.equals(ind.TextWrapModes.NONE)) {
             return "none";
         }
-        else if (textWrapPrefs.textWrapMode.equals(idd.TextWrapModes.BOUNDING_BOX_TEXT_WRAP)) {
+        else if (textWrapPrefs.textWrapMode.equals(ind.TextWrapModes.BOUNDING_BOX_TEXT_WRAP)) {
             return "bounding_box";
         }
-        else if (textWrapPrefs.textWrapMode.equals(idd.TextWrapModes.CONTOUR)) {
+        else if (textWrapPrefs.textWrapMode.equals(ind.TextWrapModes.CONTOUR)) {
             return "contour";
         }
-        else if (textWrapPrefs.textWrapMode.equals(idd.TextWrapModes.JUMP_OBJECT_TEXT_WRAP)) {
+        else if (textWrapPrefs.textWrapMode.equals(ind.TextWrapModes.JUMP_OBJECT_TEXT_WRAP)) {
             return "jump_object";
         }
-        else if (textWrapPrefs.textWrapMode.equals(idd.TextWrapModes.NEXT_COLUMN_TEXT_WRAP)) {
+        else if (textWrapPrefs.textWrapMode.equals(ind.TextWrapModes.NEXT_COLUMN_TEXT_WRAP)) {
             return "jump_to_next_column";
         }
         else {
@@ -626,7 +626,7 @@ class ExportInDesignArticlesToFolder {
         // If leading is set to Auto (value = -1), estimate it as 120% of font size.
         if (leading !== null
             && typeof leading === "object"
-            && (/** @type {object} */(leading)).equals(idd.Leading.AUTO)) {
+            && (/** @type {object} */(leading)).equals(ind.Leading.AUTO)) {
             const fontSize = Number(line.characters.item(0).pointSize);
             leading = fontSize * 1.2;
         }

--- a/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.cjs
+++ b/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.cjs
@@ -42,7 +42,7 @@ class ExportInDesignArticlesToFolder {
     }
 
     /**
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      * @param {UXP.storage.Folder} folder
      * @returns Promise<{number}> Count of exported article shapes.
      */
@@ -69,14 +69,14 @@ class ExportInDesignArticlesToFolder {
     }
 
     /**
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      * @param {UXP.storage.Folder} folder
-     * @param {IDD.Article} article
+     * @param {IND.Article} article
      * @param {number} articleIndex
      * @returns Promise>{boolean}> Whether or not successful.
      */
     async #exportArticle (doc, folder, article, articleIndex) {
-        const articleMembers = /** @type {IDD.ArticleMember} */
+        const articleMembers = /** @type {IND.ArticleMember} */
             (/** @type {unknown} */(article.articleMembers.everyItem()));
         const elements = articleMembers.getElements();
         const outerBounds = this.#getOuterboundOfArticleShape(elements);
@@ -121,20 +121,20 @@ class ExportInDesignArticlesToFolder {
     }
 
     /**
-     * @param {IDD.Article} article
-     * @param {IDD.ArticleMember[]} elements
+     * @param {IND.Article} article
+     * @param {IND.ArticleMember[]} elements
      * @param {GeoBounds} outerBounds
      * @param {ArticleShapeJson} articleShapeJson
-     * @returns {IDD.PageItem[]}
+     * @returns {IND.PageItem[]}
      */
     #collectArticlePageItems (article, elements, outerBounds, articleShapeJson) {
-        /** @type {IDD.PageItem[]} */
+        /** @type {IND.PageItem[]} */
         let pageItems = []; // Collect all associated page items for the article.
         for (let elementIndex = 0; elementIndex < elements.length; elementIndex++) {
             const element = elements[elementIndex];
             const geometricBounds = this.#composeGeometricBounds(outerBounds.topLeftX, outerBounds.topLeftY, element.itemRef);
             if (this.#inDesignArticleService.isValidTextFrame(element.itemRef)) {
-                const textFrame = /** @type {IDD.TextFrame} */(element.itemRef);
+                const textFrame = /** @type {IND.TextFrame} */(element.itemRef);
                 const threadedFrames = this.#getThreadedFrames(textFrame);
                 let textComponent = {
                     "type": textFrame.elementLabel,
@@ -236,7 +236,7 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * Compose a unique name that can be used as a base to compose export filenames.
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      * @param {UXP.storage.Folder} folder
      * @param {string} shapeTypeName
      * @param {number} articleIndex
@@ -265,7 +265,7 @@ class ExportInDesignArticlesToFolder {
      * Create a data object that describes the geometrical boundaries of a given page item.
      * @param {number} topLeftX - Make it relative to this X position.
      * @param {number} topLeftY - Make it relative to this Y position.
-     * @param {IDD.PageItem} pageItem - TextFrame, Rectangle, etc
+     * @param {IND.PageItem} pageItem - TextFrame, Rectangle, etc
      * @returns {ArticleShapeGeoBounds}
      */
     #composeGeometricBounds (topLeftX, topLeftY, pageItem) {
@@ -288,7 +288,7 @@ class ExportInDesignArticlesToFolder {
 
     /**
      *
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      * @param {string} articleName
      * @param {GeoBounds} outerBounds
      * @returns {ArticleShapeJson|null}
@@ -337,7 +337,7 @@ class ExportInDesignArticlesToFolder {
     /**
      * Tells whether all given page items are placed on the same spread. If this is not the case,
      * the items can not be selected nor grouped which is required by _exportArticlePageItems().
-     * @param {IDD.PageItem[]} pageItems
+     * @param {IND.PageItem[]} pageItems
      * @returns
      */
     #arePageItemsOnSameSpread (pageItems) {
@@ -354,11 +354,11 @@ class ExportInDesignArticlesToFolder {
     }
 
     /**
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      * @param {UXP.storage.Folder} folder
      * @param {string} shapeTypeName
      * @param {number} articleIndex
-     * @param {IDD.PageItem[]} pageItems
+     * @param {IND.PageItem[]} pageItems
      * @param {ArticleShapeJson} articleShapeJson
      * @returns {Promise<boolean>} Whether or not successful.
      */
@@ -452,7 +452,7 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * Get the word count and character count of a text frame, excluding overset text.
-     * @param {IDD.TextFrame} textFrame - The text frame to analyze.
+     * @param {IND.TextFrame} textFrame - The text frame to analyze.
      * @returns {{wordCount: number, charCount: number, text: string, totalLineHeight: number}} - An object containing word count, character count and text without overset.
      */
     #getTextStatisticsWithoutOverset (textFrame) {
@@ -485,7 +485,7 @@ class ExportInDesignArticlesToFolder {
     /**
      * Calculates the outermost bounding box of a collection of article elements, considering threaded frames if applicable.
      *
-     * @param {IDD.ArticleMember[]} elements
+     * @param {IND.ArticleMember[]} elements
      *    An array of article elements. Each element should have an `itemRef` property that represents the InDesign object.
      *    The `itemRef` can be a text frame, graphic, or other page item.
      * @returns {GeoBounds} Outer bounds of the combined elements and their threaded frames.
@@ -509,7 +509,7 @@ class ExportInDesignArticlesToFolder {
 
             //Create an array with all thread frames (images don't have threaded frames)
             if (this.#inDesignArticleService.isValidTextFrame(element.itemRef)) {
-                const textFrame = /** @type {IDD.TextFrame} */(element.itemRef);
+                const textFrame = /** @type {IND.TextFrame} */(element.itemRef);
                 threadedFrames = this.#getThreadedFrames(textFrame);
             }
             else {
@@ -540,8 +540,8 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * Get all threaded text frames for a given text frame.
-     * @param {IDD.TextFrame} textFrame The starting text frame.
-     * @returns {IDD.TextFrame[]} All threaded text frames, including the starting frame.
+     * @param {IND.TextFrame} textFrame The starting text frame.
+     * @returns {IND.TextFrame[]} All threaded text frames, including the starting frame.
      */
     #getThreadedFrames (textFrame) {
         let threadedFrames = [textFrame];
@@ -566,7 +566,7 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * @param {TextFrame | TextPath | NothingEnum} threadedSibling
-     * @returns {threadedSibling is IDD.TextFrame}
+     * @returns {threadedSibling is IND.TextFrame}
      */
     #isThreadedSiblingValidTextFrame (threadedSibling) {
         if (!threadedSibling || threadedSibling.constructorName !== "TextFrame") {
@@ -578,7 +578,7 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * Get the text wrap settings of a selected frame, including the text wrap mode as a string.
-     * @param {IDD.PageItem|null} frame TextFrame, GraphicFrame, etc
+     * @param {IND.PageItem|null} frame TextFrame, GraphicFrame, etc
      * @returns {string} Name of the text wrap mode
      */
     #getTextWrapMode (frame) {
@@ -611,7 +611,7 @@ class ExportInDesignArticlesToFolder {
 
     /**
      * Calculate the line height in points.
-     * @param {IDD.Line} line
+     * @param {IND.Line} line
      * @returns {number}
      */
     #getLineHeight (line) {

--- a/ArticleShapeExtractor/modules/FitArticleWithAIService.cjs
+++ b/ArticleShapeExtractor/modules/FitArticleWithAIService.cjs
@@ -40,7 +40,7 @@ class FitArticleWithAIService {
      * - Retrieve fitted shape from AI fitting service.
      * - Update the unfitted article with fitted shape (on the layout).
      *
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      */
     async run (doc) {
 

--- a/ArticleShapeExtractor/modules/InDesignArticleService.cjs
+++ b/ArticleShapeExtractor/modules/InDesignArticleService.cjs
@@ -76,9 +76,9 @@ class InDesignArticleService {
 
     /**
      * Collect articles the provided frame is part of.
-     * @param {IDD.Document} doc
-     * @param {IDD.PageItem} frame Valid text/graphic frame.
-     * @returns {IDD.Article[]}
+     * @param {IND.Document} doc
+     * @param {IND.PageItem} frame Valid text/graphic frame.
+     * @returns {IND.Article[]}
      */
     getInDesignArticles (doc, frame) {
         const docArticles = doc.articles;
@@ -98,12 +98,12 @@ class InDesignArticleService {
 
     /**
      * Tell whether a given page item is member of a the given InDesign Article.
-     * @param {IDD.Article} article - The InDesign article to check.
-     * @param {IDD.PageItem} frame - The frame to check for membership.
+     * @param {IND.Article} article - The InDesign article to check.
+     * @param {IND.PageItem} frame - The frame to check for membership.
      * @returns {boolean} - True if the frame is already a member of the article, false otherwise.
      */
     #isFrameMemberOfInDesignArticle (article, frame) {
-        const articleMembers = /** @type {IDD.ArticleMember} */
+        const articleMembers = /** @type {IND.ArticleMember} */
             (/** @type {unknown} */(article.articleMembers.everyItem()));
         const elements = articleMembers.getElements();
         for (let i = 0; i < elements.length; i++) {
@@ -116,7 +116,7 @@ class InDesignArticleService {
 
     /**
      * Create a new InDesign Article with the given name. Add the selected frames to the article.
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      * @param {string} articleName
      */
     #createNewInDesignArticleWithSelectedFrames (doc, articleName) {
@@ -163,7 +163,7 @@ class InDesignArticleService {
 
     /**
      * Tells whether the given page item is a valid frame and has any of the provided frame types.
-     * @param {IDD.PageItem|null} pageItem
+     * @param {IND.PageItem|null} pageItem
      * @param {string[]} frameTypes
      * @returns {boolean}
      */
@@ -175,21 +175,21 @@ class InDesignArticleService {
 
     /**
      * Tells whether the given page item is a valid text frame (to be part of an article).
-     * @param {IDD.PageItem|null} pageItem
-     * @returns {pageItem is IDD.TextFrame}
+     * @param {IND.PageItem|null} pageItem
+     * @returns {pageItem is IND.TextFrame}
      */
     isValidTextFrame (pageItem) {
         if (!this.#isValidFrameOfType(pageItem, ["TextFrame"])) {
             return false;
         }
-        const textFrame = /** @type {IDD.TextFrame} */(pageItem);
+        const textFrame = /** @type {IND.TextFrame} */(pageItem);
         return textFrame.contentType.toString() === ind.ContentType.TEXT_TYPE.toString();
     }
 
     /**
      * Tells whether the given page item is a valid graphic frame (to be part of an article).
-     * @param {IDD.PageItem|null} pageItem
-     * @returns {pageItem is IDD.Oval | IDD.Polygon | IDD.Rectangle | IDD.GraphicLine}
+     * @param {IND.PageItem|null} pageItem
+     * @returns {pageItem is IND.Oval | IND.Polygon | IND.Rectangle | IND.GraphicLine}
      */
     isValidGraphicFrame (pageItem) {
         //Note: In the future we might want to extend with idd.ContentType.GRAPHIC_TYPE.toString()
@@ -200,8 +200,8 @@ class InDesignArticleService {
     /**
      * Tells whether the given page item is a Rectangle graphic frame, but very slim, hence
      * should be interpreted as a work-around of the layouter to compose a line (GraphicLine).
-     * @param {IDD.PageItem|null} pageItem
-     * @returns {pageItem is IDD.Rectangle}
+     * @param {IND.PageItem|null} pageItem
+     * @returns {pageItem is IND.Rectangle}
      */
     #isValid1DRectangleFrame (pageItem) {
         //Note: In the future we might want to extend with idd.ContentType.GRAPHIC_TYPE.toString()
@@ -220,8 +220,8 @@ class InDesignArticleService {
      * This is either a frame of type GraphicLine or a very slim Rectangle.
      * These frames are included in "article definition" files (IDMS) but they
      * are excluded from "article composition" (JSON) files.
-     * @param {IDD.PageItem|null} pageItem
-     * @returns {pageItem is IDD.GraphicLine}
+     * @param {IND.PageItem|null} pageItem
+     * @returns {pageItem is IND.GraphicLine}
      */
     isValid1DGraphicFrame (pageItem) {
         //Note: In the future we might want to extend with idd.ContentType.GRAPHIC_TYPE.toString()
@@ -234,8 +234,8 @@ class InDesignArticleService {
      * Tells whether the given page item is a valid 2 dimensional graphic frame.
      * This includes Oval and Polygon frames, and Rectangle frames when not too slim.
      * This excludes TextFrame, GraphicLine and very slim Rectangle frames.
-     * @param {IDD.PageItem|null} pageItem
-     * @returns {pageItem is IDD.Oval | IDD.Polygon}
+     * @param {IND.PageItem|null} pageItem
+     * @returns {pageItem is IND.Oval | IND.Polygon}
      */
     isValid2DGraphicFrame (pageItem) {
         //Note: In the future we might want to extend with idd.ContentType.GRAPHIC_TYPE.toString()
@@ -249,7 +249,7 @@ class InDesignArticleService {
 
     /**
      * Tells whether the given page item is an unassigned frame (InDesign->Object->Content)
-     * @param {IDD.PageItem|null} pageItem
+     * @param {IND.PageItem|null} pageItem
      * @returns {boolean}
      */
     isUnassignedFrame (pageItem) {
@@ -261,7 +261,7 @@ class InDesignArticleService {
     /**
      * Tells whether the given page item is a valid text- or graphic frame to be part
      * of an "article definition" file (IDMS), also called InDesign Snippet.
-     * @param {IDD.PageItem|null} pageItem
+     * @param {IND.PageItem|null} pageItem
      * @returns {boolean}
      */
     isValidArticleComponentFrame (pageItem) {

--- a/ArticleShapeExtractor/modules/InDesignArticleService.cjs
+++ b/ArticleShapeExtractor/modules/InDesignArticleService.cjs
@@ -1,4 +1,4 @@
-const idd = require("indesign");
+const ind = require("indesign");
 const Errors = require("../modules/Errors.cjs");
 
 class InDesignArticleService {
@@ -14,22 +14,22 @@ class InDesignArticleService {
      * @param {string} articleName
      */
     addOrRenameInDesignArticle (articleName) {
-        if (idd.app.documents.length === 0) {
+        if (ind.app.documents.length === 0) {
             throw new Errors.NoDocumentOpenedError();
         }
 
-        const selection = /** @type {object[]} */(idd.app.selection);
+        const selection = /** @type {object[]} */(ind.app.selection);
         if (selection.length === 0) {
             throw new Errors.NoFramesSelectedError();
         }
 
-        const frame = idd.app.selection[0];
+        const frame = ind.app.selection[0];
         if (!this.isValidArticleComponentFrame(frame)) {
             throw new Errors.NoTextOrGraphicalFramesSelectedError();
         }
 
         // Add new InDesign Articles.
-        const doc = idd.app.activeDocument;
+        const doc = ind.app.activeDocument;
         const articles = this.getInDesignArticles(doc, frame);
         if (articles.length == 0) {
             this.#createNewInDesignArticleWithSelectedFrames(doc, articleName);
@@ -126,7 +126,7 @@ class InDesignArticleService {
         article.name = articleName;
 
         // Add selected frames to the new article.
-        const selection = /** @type {object[]} */(idd.app.selection);
+        const selection = /** @type {object[]} */(ind.app.selection);
         for (let i = 0; i < selection.length; i++) {
             const frame = selection[i];
             if (this.isValidArticleComponentFrame(frame)) {
@@ -183,7 +183,7 @@ class InDesignArticleService {
             return false;
         }
         const textFrame = /** @type {IDD.TextFrame} */(pageItem);
-        return textFrame.contentType.toString() === idd.ContentType.TEXT_TYPE.toString();
+        return textFrame.contentType.toString() === ind.ContentType.TEXT_TYPE.toString();
     }
 
     /**
@@ -255,7 +255,7 @@ class InDesignArticleService {
     isUnassignedFrame (pageItem) {
         return pageItem
             && pageItem.isValid
-            && pageItem.contentType.toString() === idd.ContentType.UNASSIGNED.toString();
+            && pageItem.contentType.toString() === ind.ContentType.UNASSIGNED.toString();
     }
 
     /**

--- a/ArticleShapeExtractor/modules/PageLayoutSettings.cjs
+++ b/ArticleShapeExtractor/modules/PageLayoutSettings.cjs
@@ -28,7 +28,7 @@ class PageLayoutSettings {
      * Exports the layout settings of the given layout document to a file named
      * "_manifest/page-layout-settings.json" in the given folder. When this file
      * already exists, the settings are compared instead.
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      * @param {UXP.storage.Folder} folder
      * @returns {Promise<boolean>} True when the settings are matching (or new), false otherwise.
      */
@@ -68,7 +68,7 @@ class PageLayoutSettings {
     }
 
     /**
-     * @param {IDD.Document} doc
+     * @param {IND.Document} doc
      * @param {Page} page
      * @param {number} baselineStart
      * @returns {PageLayoutSettingsDto}
@@ -107,8 +107,8 @@ class PageLayoutSettings {
     /**
      * Retrieve the baseline start field when set relative to top of page.
      * When set relative to top of margin, the returned value is normalized to top of page.
-     * @param {IDD.Document} doc
-     * @param {IDD.Page} page
+     * @param {IND.Document} doc
+     * @param {IND.Page} page
      * @returns number Baseline start (always relative to top of page).
      */
     #getBaselineStart (doc, page) {

--- a/ArticleShapeExtractor/modules/PageLayoutSettings.cjs
+++ b/ArticleShapeExtractor/modules/PageLayoutSettings.cjs
@@ -1,4 +1,4 @@
-const idd = require("indesign");
+const ind = require("indesign");
 /** @type {UXP.storage.FileSystemProvider} */
 const lfs = require("uxp").storage.localFileSystem;
 const formats = require("uxp").storage.formats;
@@ -36,14 +36,14 @@ class PageLayoutSettings {
         let exportedSuccessfully = false;
         const docName = doc.saved ? lfs.getNativePath(await doc.fullName) : doc.name;
         this.#logger.info("Exporting Document Settings for layout '{}'.", docName);
-        idd.app.scriptPreferences.measurementUnit = idd.MeasurementUnits.POINTS;
+        ind.app.scriptPreferences.measurementUnit = ind.MeasurementUnits.POINTS;
         try {
             if (doc.pages.length === 0) {
                 throw new Errors.NoDocumentPagesError();
             }
             for (let i = 0; i < doc.pages.length; i++) {
                 const pag = doc.pages.item(i);
-                const side = pag.side.equals(idd.PageSideOptions.LEFT_HAND) ? "left" : "right";
+                const side = pag.side.equals(ind.PageSideOptions.LEFT_HAND) ? "left" : "right";
                 this.#logger.debug(`Page: id=${pag.id}, index=${pag.index}, name=${pag.name}, side=${side}`);
             }
             const page = doc.pages.item(0);
@@ -62,7 +62,7 @@ class PageLayoutSettings {
             alert("An error occurred: " + error.message);
         }
         finally {
-            idd.app.scriptPreferences.measurementUnit = idd.AutoEnum.AUTO_VALUE;
+            ind.app.scriptPreferences.measurementUnit = ind.AutoEnum.AUTO_VALUE;
         }
         return exportedSuccessfully;
     }
@@ -114,7 +114,7 @@ class PageLayoutSettings {
     #getBaselineStart (doc, page) {
         let baselineStart = Number(doc.gridPreferences.baselineStart);
         const isGridRelativeToPageMargins = doc.gridPreferences.baselineGridRelativeOption.equals(
-            idd.BaselineGridRelativeOption.TOP_OF_MARGIN_OF_BASELINE_GRID_RELATIVE_OPTION);
+            ind.BaselineGridRelativeOption.TOP_OF_MARGIN_OF_BASELINE_GRID_RELATIVE_OPTION);
         if (isGridRelativeToPageMargins) {
             baselineStart += Number(page.marginPreferences.top);
             this.#logger.debug(

--- a/ArticleShapeExtractor/modules/RegenerateArticleShapesService.cjs
+++ b/ArticleShapeExtractor/modules/RegenerateArticleShapesService.cjs
@@ -1,4 +1,4 @@
-const idd = require("indesign");
+const ind = require("indesign");
 const Errors = require("./Errors.cjs");
 
 /**
@@ -99,9 +99,9 @@ class RegenerateArticleShapesService {
                 if (mapItem) for (const oldFile of mapItem.shapeFiles) {
                     await this.#deleteFile(oldFile);
                 }
-                const theOpenDoc = idd.app.openObject(wflObject.ID, false); // false: no checkout
+                const theOpenDoc = ind.app.openObject(wflObject.ID, false); // false: no checkout
                 const shapeCount = await this.#exportInDesignArticlesToFolder.run(theOpenDoc, folder);
-                theOpenDoc.close(idd.SaveOptions.NO);
+                theOpenDoc.close(ind.SaveOptions.NO);
                 if (shapeCount > 0) {
                     extractedLayoutIds.push(wflObject.ID);
                 }

--- a/ArticleShapeExtractor/types/indesign-aliases.d.ts
+++ b/ArticleShapeExtractor/types/indesign-aliases.d.ts
@@ -3,7 +3,7 @@
 export {};
 
 declare global {
-  declare namespace IDD { 
+  declare namespace IND { 
     type Application = globalThis.Application;
     type Article = globalThis.Article;
     type ArticleMember = globalThis.ArticleMember;

--- a/ArticleShapeExtractor/types/indesign-module.d.ts
+++ b/ArticleShapeExtractor/types/indesign-module.d.ts
@@ -2,18 +2,18 @@
 
 declare module "indesign" {
   export const idd: IDD;
-  export const app: IDD.Application;
+  export const app: IND.Application;
 
-  export const AutoEnum: IDD.AutoEnum;
-  export const BaselineGridRelativeOption: IDD.BaselineGridRelativeOption;
-  export const ContentType: IDD.ContentType;
-  export const ExportFormat: IDD.ExportFormat;
-  export const JPEGOptionsQuality: IDD.JPEGOptionsQuality;
-  export const JPEGOptionsFormat: IDD.JPEGOptionsFormat;
-  export const JpegColorSpaceEnum: IDD.JpegColorSpaceEnum;
-  export const Leading: IDD.Leading;
-  export const MeasurementUnits: IDD.MeasurementUnits;
-  export const PageSideOptions: IDD.PageSideOptions
-  export const SaveOptions: IDD.SaveOptions;
-  export const TextWrapModes: IDD.TextWrapModes;
+  export const AutoEnum: IND.AutoEnum;
+  export const BaselineGridRelativeOption: IND.BaselineGridRelativeOption;
+  export const ContentType: IND.ContentType;
+  export const ExportFormat: IND.ExportFormat;
+  export const JPEGOptionsQuality: IND.JPEGOptionsQuality;
+  export const JPEGOptionsFormat: IND.JPEGOptionsFormat;
+  export const JpegColorSpaceEnum: IND.JpegColorSpaceEnum;
+  export const Leading: IND.Leading;
+  export const MeasurementUnits: IND.MeasurementUnits;
+  export const PageSideOptions: IND.PageSideOptions
+  export const SaveOptions: IND.SaveOptions;
+  export const TextWrapModes: IND.TextWrapModes;
 }


### PR DESCRIPTION
Rename idd into ind to use a more logical abbreviation for InDesign.
Rename IDD into IND to use a more logical abbreviation for InDesign.