### PR TITLE
LA-224 AI fitting - step 12 - bugfix for tagging threaded text frames

### DIFF
--- a/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.cjs
+++ b/ArticleShapeExtractor/modules/ExportInDesignArticlesToFolder.cjs
@@ -153,7 +153,7 @@ class ExportInDesignArticlesToFolder {
             const geometricBounds = this.#composeGeometricBounds(outerBounds.topLeftX, outerBounds.topLeftY, element.itemRef);
             if (this.#inDesignArticleService.isValidTextFrame(element.itemRef)) {
                 const textFrame = /** @type {IND.TextFrame} */(element.itemRef);
-                const threadedFrames = this.#getThreadedFrames(textFrame);
+                const threadedFrames = this.#inDesignArticleService.getThreadedFrames(textFrame);
                 let textComponent = {
                     "type": textFrame.elementLabel,
                     "words": 0,
@@ -530,7 +530,7 @@ class ExportInDesignArticlesToFolder {
             //Create an array with all thread frames (images don't have threaded frames)
             if (this.#inDesignArticleService.isValidTextFrame(element.itemRef)) {
                 const textFrame = /** @type {IND.TextFrame} */(element.itemRef);
-                threadedFrames = this.#getThreadedFrames(textFrame);
+                threadedFrames = this.#inDesignArticleService.getThreadedFrames(textFrame);
             }
             else {
                 threadedFrames = [element.itemRef];
@@ -555,45 +555,6 @@ class ExportInDesignArticlesToFolder {
         }
 
         return { topLeftX: topLeftX, topLeftY: topLeftY, bottomRightX: bottomRightX, bottomRightY: bottomRightY };
-    }
-
-
-    /**
-     * Get all threaded text frames for a given text frame.
-     * @param {IND.TextFrame} textFrame The starting text frame.
-     * @returns {IND.TextFrame[]} All threaded text frames, including the starting frame.
-     */
-    #getThreadedFrames (textFrame) {
-        let threadedFrames = [textFrame];
-
-        // Traverse forward through the thread chain
-        /** @type {TextFrame | TextPath | NothingEnum} */
-        let threadedSibling = textFrame.nextTextFrame;
-        while (this.#isThreadedSiblingValidTextFrame(threadedSibling)) {
-            threadedFrames.push(threadedSibling); // append at end
-            threadedSibling = threadedSibling.nextTextFrame;
-        }
-
-        // Traverse backward through the thread chain
-        threadedSibling = textFrame.previousTextFrame;
-        while (this.#isThreadedSiblingValidTextFrame(threadedSibling)) {
-            threadedFrames.unshift(threadedSibling); // insert at start
-            threadedSibling = threadedSibling.previousTextFrame;
-        }
-
-        return threadedFrames;
-    }
-
-    /**
-     * @param {TextFrame | TextPath | NothingEnum} threadedSibling
-     * @returns {threadedSibling is IND.TextFrame}
-     */
-    #isThreadedSiblingValidTextFrame (threadedSibling) {
-        if (!threadedSibling || threadedSibling.constructorName !== "TextFrame") {
-            return false;
-        }
-        const textFrame = /** @type {TextFrame} */(threadedSibling);
-        return this.#inDesignArticleService.isValidTextFrame(textFrame);
     }
 
     /**

--- a/ArticleShapeExtractor/modules/FitArticleWithAIService.cjs
+++ b/ArticleShapeExtractor/modules/FitArticleWithAIService.cjs
@@ -76,8 +76,12 @@ class FitArticleWithAIService {
         const { brand, section } = this.#brandSectionResolver.resolve(doc);
 
         // Export the contextual article to a temp work folder.
-        const tempFolder = await this.#fileUtils.getTempFolder();
-        const articles = this.#inDesignArticleService.getSelectedInDesignArticles(doc);
+        const articleFrames = this.#inDesignArticleService.getSelectedArticleFrames(doc);
+        if (articleFrames.length === 0) {
+            throw new Errors.NoTextOrGraphicalFramesSelectedError();
+        }
+        const tempFolder = await this.#fileUtils.getOrCreateTempFolder();
+        const articles = this.#inDesignArticleService.getInDesignArticlesForArticleFrames(doc, articleFrames);
         for (let articleIndex = 0; articleIndex < articles.length; articleIndex++) {
             const article = articles[articleIndex];
             const articleSuffix = String(articleIndex + 1);

--- a/ArticleShapeExtractor/modules/InDesignArticleService.cjs
+++ b/ArticleShapeExtractor/modules/InDesignArticleService.cjs
@@ -1,6 +1,19 @@
 const ind = require("indesign");
 const Errors = require("../modules/Errors.cjs");
 
+/**
+ * A *ValidArticleFrame* is a page item that can be part of an InDesign Article.
+ * The page item is valid and can be either a text frame or a graphic frame.
+ *
+ * For frames part of a threaded text story, this always refers to the **first** TextFrame.
+ * Succeeding frames of type TextFrame in the thread are *not* considered valid article frames.
+ * When the first frame in the thread is of type TextPath, the next TextFrame in the thread is used.
+ *
+ * Graphic frames and non-threaded text frames (of type TextFrame) are used as-is.
+ *
+ * @typedef {IND.TextFrame} ValidArticleFrame
+ */
+
 class InDesignArticleService {
 
     /**
@@ -17,10 +30,13 @@ class InDesignArticleService {
 
         // Add new InDesign Articles.
         const doc = this.getActiveDocument();
-        const articles = this.getSelectedInDesignArticles(doc);
+        const articleFrames = this.getSelectedArticleFrames(doc);
+        if (articleFrames.length === 0) {
+            throw new Errors.NoTextOrGraphicalFramesSelectedError();
+        }
+        const articles = this.getInDesignArticlesForArticleFrames(doc, articleFrames);
         if (articles.length == 0) {
-            const doc = ind.app.activeDocument;
-            this.#createNewInDesignArticleWithSelectedFrames(doc, articleName);
+            this.#createNewInDesignArticleWithArticleFrames(doc, articleName, articleFrames);
             alert("A new article '" + articleName + "' has been created, and selected frames have been added.");
             return;
         }
@@ -50,27 +66,6 @@ class InDesignArticleService {
                 alert("Article \"" + oldName + "\" has been renamed to \"" + newName + "\"");
             }
         }
-    }
-
-    /**
-     * @param {IND.Document} doc
-     * @returns {IND.Article[]} The InDesign Articles for the currently selected frames.
-     */
-    getSelectedInDesignArticles (doc) {
-        const selectedObjects = this.#getSelectedObjects(doc);
-        /** @type {IND.PageItem[]} */
-        let articlePageItems = [];
-        for (let i = 0; i < selectedObjects.length; i++) {
-            const selectedObject = selectedObjects[i];
-            if (this.isValidArticleComponentFrame(selectedObject)) {
-                articlePageItems.push(/** @type {IND.PageItem} */(selectedObject));
-            }
-        }
-        if (articlePageItems.length === 0) {
-            throw new Errors.NoTextOrGraphicalFramesSelectedError();
-        }
-        const articles = this.getInDesignArticles(doc, articlePageItems);
-        return articles;
     }
 
     /**
@@ -112,20 +107,20 @@ class InDesignArticleService {
     /**
      * Collect articles the provided frame is part of.
      * @param {IND.Document} doc
-     * @param {IND.PageItem[]} pageItems Valid text/graphic frame.
+     * @param {ValidArticleFrame[]} articleFrames
      * @returns {IND.Article[]}
      */
-    getInDesignArticles (doc, pageItems) {
+    getInDesignArticlesForArticleFrames (doc, articleFrames) {
         const docArticles = doc.articles;
         let foundArticles = [];
 
         // Loop through all articles to check if the frame is a member
         for (let i = 0; i < docArticles.length; i++) {
             const docArticle = docArticles.item(i);
-            for (let j = 0; j < pageItems.length; j++) {
-                const pageItem = pageItems[j];
+            for (let j = 0; j < articleFrames.length; j++) {
+                const articleFrame = articleFrames[j];
                 // Check if the frame is in the article's members
-                if (this.#isFrameMemberOfInDesignArticle(docArticle, pageItem)) {
+                if (this.#isArticleFrameMemberOfInDesignArticle(docArticle, articleFrame)) {
                     foundArticles.push(docArticle);
                     break; // take next article (prevent duplicates)
                 }
@@ -137,15 +132,15 @@ class InDesignArticleService {
     /**
      * Tell whether a given page item is member of a the given InDesign Article.
      * @param {IND.Article} article - The InDesign article to check.
-     * @param {IND.PageItem} frame - The frame to check for membership.
+     * @param {ValidArticleFrame} articleFrame - The frame to check for membership.
      * @returns {boolean} - True if the frame is already a member of the article, false otherwise.
      */
-    #isFrameMemberOfInDesignArticle (article, frame) {
+    #isArticleFrameMemberOfInDesignArticle (article, articleFrame) {
         const articleMembers = /** @type {IND.ArticleMember} */
             (/** @type {unknown} */(article.articleMembers.everyItem()));
         const elements = articleMembers.getElements();
         for (let i = 0; i < elements.length; i++) {
-            if (elements[i].itemRef.equals(frame)) {
+            if (elements[i].itemRef.equals(articleFrame)) {
                 return true; // The frame is already a member of the article
             }
         }
@@ -153,29 +148,56 @@ class InDesignArticleService {
     }
 
     /**
-     * Create a new InDesign Article with the given name. Add the selected frames to the article.
+     * Create a new InDesign Article with the given name. Add the frames to the article.
      * @param {IND.Document} doc
+     * @param {ValidArticleFrame[]} articleFrames
      * @param {string} articleName
      */
-    #createNewInDesignArticleWithSelectedFrames (doc, articleName) {
+    #createNewInDesignArticleWithArticleFrames (doc, articleName, articleFrames) {
 
         // Create a new InDesign Article (even if an article with the same name already exists).
         const article = doc.articles.add();
         article.name = articleName;
 
         // Add selected frames to the new article.
-        const selection = /** @type {object[]} */(ind.app.selection);
-        for (let i = 0; i < selection.length; i++) {
-            const frame = selection[i];
-            if (this.isValidArticleComponentFrame(frame)) {
-                try {
-                    article.articleMembers.add(frame);
-                }
-                catch {
-                    // Intentionally ignored
-                }
+        for (let i = 0; i < articleFrames.length; i++) {
+            try {
+                article.articleMembers.add(articleFrames[i]);
+            }
+            catch {
+                // Intentionally ignored
             }
         }
+    }
+
+    /**
+     * Filter the provided page items and return only unique and valid article text/graphic frames.
+     * When a text frame is part of a text thread, only the first text frame in the thread is returned.
+     * @param {IND.Document} doc
+     * @returns {ValidArticleFrame[]}
+     */
+    getSelectedArticleFrames (doc) {
+
+        /** @type {Map<number, IND.PageItem>} */
+        const uniqueFrames = new Map();
+        const selectedObjects = this.#getSelectedObjects(doc);
+
+        for (let i = 0; i < selectedObjects.length; i++) {
+            const pageItem = selectedObjects[i];
+            let frameToAdd = null;
+            if (this.isValidTextFrame(pageItem)) {
+                frameToAdd = this.#getFirstTextFrameInThread(
+                    /** @type {IND.PageItem} */ (pageItem),
+                );
+            }
+            else if (this.isValidGraphicFrame(pageItem)) {
+                frameToAdd = /** @type {IND.PageItem} */ (pageItem);
+            }
+            if (frameToAdd && !uniqueFrames.has(frameToAdd.id)) {
+                uniqueFrames.set(frameToAdd.id, frameToAdd);
+            }
+        }
+        return Array.from(uniqueFrames.values());
     }
 
     /**
@@ -214,7 +236,7 @@ class InDesignArticleService {
     /**
      * Tells whether the given page item is a valid text frame (to be part of an article).
      * @param {IND.PageItem|null} pageItem
-     * @returns {pageItem is IND.TextFrame}
+     * @returns {pageItem is ValidArticleFrame}
      */
     isValidTextFrame (pageItem) {
         if (!this.#isValidFrameOfType(pageItem, ["TextFrame"])) {
@@ -305,6 +327,62 @@ class InDesignArticleService {
     isValidArticleComponentFrame (pageItem) {
         return this.isValidTextFrame(pageItem)
             || this.isValidGraphicFrame(pageItem);
+    }
+
+    /**
+     * Get all threaded text frames for a given text frame.
+     * @param {IND.TextFrame} textFrame Any text frame within the thread.
+     * @returns {ValidArticleFrame[]} All text frames in the thread, including the provided frame.
+     */
+    getThreadedFrames (textFrame) {
+        let threadedFrames = [textFrame];
+
+        // Traverse forward through the thread chain
+        /** @type {TextFrame | TextPath | NothingEnum} */
+        let threadedSibling = textFrame.nextTextFrame;
+        while (this.#isThreadedSiblingValidTextFrame(threadedSibling)) {
+            threadedFrames.push(threadedSibling); // append at end
+            threadedSibling = threadedSibling.nextTextFrame;
+        }
+
+        // Traverse backward through the thread chain
+        threadedSibling = textFrame.previousTextFrame;
+        while (this.#isThreadedSiblingValidTextFrame(threadedSibling)) {
+            threadedFrames.unshift(threadedSibling); // insert at start
+            threadedSibling = threadedSibling.previousTextFrame;
+        }
+
+        return threadedFrames;
+    }
+
+    /**
+     * @param {IND.TextFrame | IND.TextPath | IND.NothingEnum} threadedSibling
+     * @returns {threadedSibling is IND.TextFrame}
+     */
+    #isThreadedSiblingValidTextFrame (threadedSibling) {
+        if (!threadedSibling || threadedSibling.constructorName !== "TextFrame") {
+            return false;
+        }
+        const textFrame = /** @type {TextFrame} */(threadedSibling);
+        return this.isValidTextFrame(textFrame);
+    }
+
+    /**
+     * Return the first TextFrame in the text thread.
+     * Skips any TextPath in the thread.
+     *
+     * @param {IND.TextFrame} textFrame
+     * @returns {ValidArticleFrame}
+     */
+    #getFirstTextFrameInThread (textFrame) {
+        let firsTextFrame = textFrame.startTextFrame; // May be TextFrame or TextPath.
+        while (firsTextFrame && !firsTextFrame.equals(ind.NothingEnum.NOTHING)) {
+            if (this.#isThreadedSiblingValidTextFrame (firsTextFrame)) {
+                return firsTextFrame;
+            }
+            firsTextFrame = firsTextFrame.nextTextFrame;
+        }
+        return textFrame; // Should never reach here.
     }
 }
 

--- a/ArticleShapeExtractor/types/indesign-aliases.d.ts
+++ b/ArticleShapeExtractor/types/indesign-aliases.d.ts
@@ -19,6 +19,7 @@ declare global {
     type Preference = globalThis.Preference;
     type Rectangle = globalThis.Rectangle;
     type TextFrame = globalThis.TextFrame;
+    type TextPath = globalThis.TextPath;
 
     // enums/constants
     type AutoEnum = typeof AutoEnum;
@@ -30,6 +31,7 @@ declare global {
     type JpegColorSpaceEnum = typeof JpegColorSpaceEnum;
     type Leading = typeof Leading;
     type MeasurementUnits = typeof MeasurementUnits;
+    type NothingEnum = typeof NothingEnum;
     type PageSideOptions = typeof PageSideOptions;
     type SaveOptions = typeof SaveOptions;
     type TextWrapModes = typeof TextWrapModes;

--- a/ArticleShapeExtractor/types/indesign-module.d.ts
+++ b/ArticleShapeExtractor/types/indesign-module.d.ts
@@ -13,6 +13,7 @@ declare module "indesign" {
   export const JpegColorSpaceEnum: IND.JpegColorSpaceEnum;
   export const Leading: IND.Leading;
   export const MeasurementUnits: IND.MeasurementUnits;
+  export const NothingEnum: IND.NothingEnum;
   export const PageSideOptions: IND.PageSideOptions
   export const SaveOptions: IND.SaveOptions;
   export const TextWrapModes: IND.TextWrapModes;


### PR DESCRIPTION
When tagging, having selected only the 2nd frame of threaded frames, the InDesign Article creation went wrong; Always a new InDesign Article got created (bug#1) and the 2nd frame got added (bug#2). Same problem when having any other succeeding frame(s) selected, except for the first frame of the thread. 
* Bug#1: It should not create an InDesign Article when the frame already belongs one. In that case, it should rename the article. 
* Bug#2: It should always add the first text frame of the threaded frames to the article, and not any of its succeeding frames.

Note that this was fixed as a preparation step for the AI fitting feature. For this feature,  the frame selection logic is shared with the _tagging_- and _export_ features. So when you'd select a 2nd frame of a thread, and click the `Fit Article with AI` menu item, it needs to resolve the correct InDesign Articles, indirectly being "selected".